### PR TITLE
Explicitly specify `-std=c++17` for gcc-10 compatibility

### DIFF
--- a/src/kernels/build.rs
+++ b/src/kernels/build.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
     }
 
     if !is_target_msvc {
-        builder = builder.arg("-Xcompiler").arg("-fPIC");
+        builder = builder.arg("-Xcompiler").arg("-fPIC").arg("-std=c++17");
     }
 
     println!("cargo:info={builder:?}");


### PR DESCRIPTION
On some older gcc compilers (e.g., gcc-10), the build option `-std=c++17` must be explicitly specified. Without this, compilation fails with errors such as:

```
src/sort.cu(10): error: namespace "std" has no member "is_floating_point_v"
        static const bool value = std::is_floating_point_v<T>;
```

This change ensures compatibility with compilers that do not default to C++17.