### PR TITLE
Add Fused RoPE Kernel for CUDA and Metal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "attention-rs"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [dependencies]

--- a/src/fused_rope.rs
+++ b/src/fused_rope.rs
@@ -1,7 +1,10 @@
 //! Fused Rotary Position Embedding (RoPE) CUDA kernel interface
 //!
 //! This module provides a high-performance fused rotary embedding implementation
-//! that operates on both Q and K tensors simultaneously in-place.
+//! that fuses two operations:
+//!   1. Position-based cos/sin selection (eliminates index_select kernel)
+//!   2. Rotary position embedding application
+//!
 //! Supports Grouped Query Attention (GQA) where Q and K have different head counts.
 
 use candle_core::{DType, Result, Tensor};
@@ -11,19 +14,21 @@ use kernels::ffi;
 
 /// Fused Rotary Position Embedding
 ///
-/// Applies rotary position embedding to Q and K tensors in-place using optimized CUDA kernels.
-/// Supports both interleaved and non-interleaved layouts.
-/// Supports GQA where Q and K have different numbers of heads.
+/// Applies rotary position embedding to Q and K tensors using optimized CUDA kernels.
+/// Fuses the position-based cos/sin selection with the RoPE computation.
 pub struct FusedRope;
 
 impl FusedRope {
-    /// Apply fused rotary embedding to Q and K tensors in-place.
+    /// Apply fused rotary embedding with position-based cos/sin selection.
+    ///
+    /// This fuses index_select + RoPE into a single kernel, eliminating one kernel launch.
     ///
     /// # Arguments
     /// * `q` - Query tensor, shape [batch, num_q_heads, seq_len, head_dim]
     /// * `k` - Key tensor, shape [batch, num_kv_heads, seq_len, head_dim]
-    /// * `cos` - Cosine values, shape [seq_len, head_dim/2]
-    /// * `sin` - Sine values, shape [seq_len, head_dim/2]
+    /// * `cos` - FULL cosine table, shape [max_seq_len, head_dim/2]
+    /// * `sin` - FULL sine table, shape [max_seq_len, head_dim/2]
+    /// * `positions` - Position indices, shape [seq_len] (i64)
     /// * `is_interleaved` - If true, uses interleaved layout (adjacent pairs)
     ///
     /// # Returns
@@ -34,17 +39,17 @@ impl FusedRope {
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
         is_interleaved: bool,
     ) -> Result<(Tensor, Tensor)> {
         use candle_core::cuda_backend::cudarc::driver::DevicePtr;
         use candle_core::cuda_backend::CudaStorageSlice;
 
         // Validate inputs - Q and K can have different head counts (GQA)
-        let (b, q_h, t, d) = q.dims4()?;
-        let (kb, k_h, kt, kd) = k.dims4()?;
+        let (b, q_h, seq_len, d) = q.dims4()?;
+        let (kb, k_h, k_seq_len, kd) = k.dims4()?;
 
-        // Batch, seq_len, head_dim must match; heads can differ
-        if b != kb || t != kt || d != kd {
+        if b != kb || seq_len != k_seq_len || d != kd {
             candle_core::bail!(
                 "Q and K batch/seq_len/head_dim must match, got Q: {:?}, K: {:?}",
                 q.shape(),
@@ -52,27 +57,22 @@ impl FusedRope {
             );
         }
 
-        // Check cos/sin dimensions
-        let cos_shape = cos.dims();
-        let sin_shape = sin.dims();
-
-        if cos_shape != sin_shape {
+        // Positions should be 1D with length seq_len
+        let pos_shape = positions.dims();
+        if pos_shape.len() != 1 || pos_shape[0] != seq_len {
             candle_core::bail!(
-                "cos and sin shapes must match, got cos: {:?}, sin: {:?}",
-                cos_shape,
-                sin_shape
+                "positions should be [seq_len], got {:?}, expected [{}]",
+                pos_shape,
+                seq_len
             );
         }
 
-        // cos/sin should be [seq_len, head_dim/2] or similar
-        let expected_last_dim = d / 2;
-        if cos_shape.len() < 1 || cos_shape[cos_shape.len() - 1] != expected_last_dim {
-            candle_core::bail!(
-                "cos/sin last dimension should be {}, got {:?}",
-                expected_last_dim,
-                cos_shape
-            );
-        }
+        // Ensure positions is i64
+        let positions = if positions.dtype() != DType::I64 {
+            positions.to_dtype(DType::I64)?
+        } else {
+            positions.clone()
+        };
 
         // Ensure contiguity
         let q = if !q.is_contiguous() {
@@ -95,12 +95,17 @@ impl FusedRope {
         } else {
             sin.clone()
         };
+        let positions = if !positions.is_contiguous() {
+            positions.contiguous()?
+        } else {
+            positions
+        };
 
-        // Validate dtypes match
+        // Validate dtypes match (except positions which is always i64)
         let dtype = q.dtype();
         if k.dtype() != dtype || cos.dtype() != dtype || sin.dtype() != dtype {
             candle_core::bail!(
-                "All tensors must have the same dtype, got Q: {:?}, K: {:?}, cos: {:?}, sin: {:?}",
+                "Q, K, cos, sin must have same dtype, got Q: {:?}, K: {:?}, cos: {:?}, sin: {:?}",
                 q.dtype(),
                 k.dtype(),
                 cos.dtype(),
@@ -112,79 +117,95 @@ impl FusedRope {
         let dev = q.device().as_cuda_device()?;
         let stream = *dev.cu_stream() as i64;
 
-        // Calculate kernel parameters - separate bh for Q and K
+        // Calculate kernel parameters
         let q_bh = (b * q_h) as u32;
         let k_bh = (b * k_h) as u32;
-        let td = (t * d) as u32;
-        let d_param = d as u32;
-        let stride_b = 0u32; // No batch stride for now (shared cos/sin across batch)
-
-        // Get storage and call appropriate kernel
-        let q_storage = q.storage_and_layout().0;
-        let k_storage = k.storage_and_layout().0;
-        let cos_storage = cos.storage_and_layout().0;
-        let sin_storage = sin.storage_and_layout().0;
-
-        let q_cuda = match &*q_storage {
-            candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("Q must be on CUDA device"),
-        };
-        let k_cuda = match &*k_storage {
-            candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("K must be on CUDA device"),
-        };
-        let cos_cuda = match &*cos_storage {
-            candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("cos must be on CUDA device"),
-        };
-        let sin_cuda = match &*sin_storage {
-            candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("sin must be on CUDA device"),
-        };
+        let seq_len_u32 = seq_len as u32;
+        let d_u32 = d as u32;
 
         // Clone for output
         let q_out = q.clone();
         let k_out = k.clone();
 
+        // Get storage
         let q_out_storage = q_out.storage_and_layout().0;
         let k_out_storage = k_out.storage_and_layout().0;
+        let cos_storage = cos.storage_and_layout().0;
+        let sin_storage = sin.storage_and_layout().0;
+        let pos_storage = positions.storage_and_layout().0;
 
         let q_out_cuda = match &*q_out_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("Q output must be on CUDA device"),
+            _ => candle_core::bail!("Q must be on CUDA"),
         };
         let k_out_cuda = match &*k_out_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("K output must be on CUDA device"),
+            _ => candle_core::bail!("K must be on CUDA"),
+        };
+        let cos_cuda = match &*cos_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("cos must be on CUDA"),
+        };
+        let sin_cuda = match &*sin_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("sin must be on CUDA"),
+        };
+        let pos_cuda = match &*pos_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("positions must be on CUDA"),
+        };
+
+        // Get positions pointer
+        let pos_ptr = match &pos_cuda.slice {
+            CudaStorageSlice::I64(s) => *s.device_ptr() as *const i64,
+            _ => candle_core::bail!("positions must be I64"),
         };
 
         match dtype {
             DType::F32 => {
                 let q_ptr = match &q_out_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let k_ptr = match &k_out_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_f32(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_f32(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
@@ -192,29 +213,47 @@ impl FusedRope {
             DType::F16 => {
                 let q_ptr = match &q_out_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let k_ptr = match &k_out_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_f16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_f16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
@@ -222,70 +261,76 @@ impl FusedRope {
             DType::BF16 => {
                 let q_ptr = match &q_out_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let k_ptr = match &k_out_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_bf16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_bf16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
             }
-            _ => candle_core::bail!(
-                "FusedRope only supports F32, F16, and BF16 dtypes, got {:?}",
-                dtype
-            ),
+            _ => candle_core::bail!("FusedRope only supports F32, F16, BF16, got {:?}", dtype),
         }
 
         Ok((q_out, k_out))
     }
 
-    /// Apply fused rotary embedding to Q and K tensors truly in-place.
-    /// This modifies the input tensors directly and returns Result<()>.
+    /// Apply fused rotary embedding in-place.
     ///
-    /// # Arguments
-    /// * `q` - Query tensor, shape [batch, num_q_heads, seq_len, head_dim] (modified in-place)
-    /// * `k` - Key tensor, shape [batch, num_kv_heads, seq_len, head_dim] (modified in-place)
-    /// * `cos` - Cosine values, shape [seq_len, head_dim/2]
-    /// * `sin` - Sine values, shape [seq_len, head_dim/2]
-    /// * `is_interleaved` - If true, uses interleaved layout (adjacent pairs)
-    ///
-    /// # Returns
-    /// Result<()> indicating success or failure
+    /// Same as `apply` but modifies Q and K directly.
     #[cfg(feature = "cuda")]
     pub fn apply_inplace(
         q: &Tensor,
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
         is_interleaved: bool,
     ) -> Result<()> {
         use candle_core::cuda_backend::cudarc::driver::DevicePtr;
         use candle_core::cuda_backend::CudaStorageSlice;
 
-        // Validate inputs - Q and K can have different head counts (GQA)
-        let (b, q_h, t, d) = q.dims4()?;
-        let (kb, k_h, kt, kd) = k.dims4()?;
+        let (b, q_h, seq_len, d) = q.dims4()?;
+        let (kb, k_h, k_seq_len, kd) = k.dims4()?;
 
-        if b != kb || t != kt || d != kd {
+        if b != kb || seq_len != k_seq_len || d != kd {
             candle_core::bail!(
                 "Q and K batch/seq_len/head_dim must match, got Q: {:?}, K: {:?}",
                 q.shape(),
@@ -293,105 +338,113 @@ impl FusedRope {
             );
         }
 
-        // Check cos/sin dimensions
-        let cos_shape = cos.dims();
-        let sin_shape = sin.dims();
-
-        if cos_shape != sin_shape {
-            candle_core::bail!(
-                "cos and sin shapes must match, got cos: {:?}, sin: {:?}",
-                cos_shape,
-                sin_shape
-            );
+        // Tensors must be contiguous for in-place
+        if !q.is_contiguous() || !k.is_contiguous() || !cos.is_contiguous() || !sin.is_contiguous()
+        {
+            candle_core::bail!("All tensors must be contiguous for in-place operation");
         }
 
-        // Tensors should already be contiguous for in-place ops
-        if !q.is_contiguous() {
-            candle_core::bail!("Q must be contiguous for in-place operation");
-        }
-        if !k.is_contiguous() {
-            candle_core::bail!("K must be contiguous for in-place operation");
-        }
-        if !cos.is_contiguous() {
-            candle_core::bail!("cos must be contiguous for in-place operation");
-        }
-        if !sin.is_contiguous() {
-            candle_core::bail!("sin must be contiguous for in-place operation");
-        }
+        let positions = if positions.dtype() != DType::I64 {
+            positions.to_dtype(DType::I64)?
+        } else {
+            positions.clone()
+        };
+        let positions = if !positions.is_contiguous() {
+            positions.contiguous()?
+        } else {
+            positions
+        };
 
-        // Validate dtypes match
         let dtype = q.dtype();
         if k.dtype() != dtype || cos.dtype() != dtype || sin.dtype() != dtype {
-            candle_core::bail!(
-                "All tensors must have the same dtype, got Q: {:?}, K: {:?}, cos: {:?}, sin: {:?}",
-                q.dtype(),
-                k.dtype(),
-                cos.dtype(),
-                sin.dtype()
-            );
+            candle_core::bail!("Q, K, cos, sin must have same dtype");
         }
 
-        // Get device
         let dev = q.device().as_cuda_device()?;
         let stream = *dev.cu_stream() as i64;
 
-        // Calculate kernel parameters - separate bh for Q and K
         let q_bh = (b * q_h) as u32;
         let k_bh = (b * k_h) as u32;
-        let td = (t * d) as u32;
-        let d_param = d as u32;
-        let stride_b = 0u32;
+        let seq_len_u32 = seq_len as u32;
+        let d_u32 = d as u32;
 
-        // Get storage - directly use input tensors (in-place)
         let q_storage = q.storage_and_layout().0;
         let k_storage = k.storage_and_layout().0;
         let cos_storage = cos.storage_and_layout().0;
         let sin_storage = sin.storage_and_layout().0;
+        let pos_storage = positions.storage_and_layout().0;
 
         let q_cuda = match &*q_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("Q must be on CUDA device"),
+            _ => candle_core::bail!("Q must be on CUDA"),
         };
         let k_cuda = match &*k_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("K must be on CUDA device"),
+            _ => candle_core::bail!("K must be on CUDA"),
         };
         let cos_cuda = match &*cos_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("cos must be on CUDA device"),
+            _ => candle_core::bail!("cos must be on CUDA"),
         };
         let sin_cuda = match &*sin_storage {
             candle_core::Storage::Cuda(s) => s,
-            _ => candle_core::bail!("sin must be on CUDA device"),
+            _ => candle_core::bail!("sin must be on CUDA"),
+        };
+        let pos_cuda = match &*pos_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("positions must be on CUDA"),
+        };
+
+        let pos_ptr = match &pos_cuda.slice {
+            CudaStorageSlice::I64(s) => *s.device_ptr() as *const i64,
+            _ => candle_core::bail!("positions must be I64"),
         };
 
         match dtype {
             DType::F32 => {
                 let q_ptr = match &q_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let k_ptr = match &k_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
-                    _ => candle_core::bail!("Expected F32 storage"),
+                    _ => candle_core::bail!("Expected F32"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_f32(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_f32(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
@@ -399,29 +452,47 @@ impl FusedRope {
             DType::F16 => {
                 let q_ptr = match &q_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let k_ptr = match &k_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected F16 storage"),
+                    _ => candle_core::bail!("Expected F16"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_f16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_f16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
@@ -429,83 +500,102 @@ impl FusedRope {
             DType::BF16 => {
                 let q_ptr = match &q_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let k_ptr = match &k_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let cos_ptr = match &cos_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
                 let sin_ptr = match &sin_cuda.slice {
                     CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
-                    _ => candle_core::bail!("Expected BF16 storage"),
+                    _ => candle_core::bail!("Expected BF16"),
                 };
 
                 unsafe {
                     if is_interleaved {
                         ffi::fused_rope_i_bf16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     } else {
                         ffi::fused_rope_bf16(
-                            q_ptr, k_ptr, cos_ptr, sin_ptr, q_bh, k_bh, td, d_param, stride_b, stream,
+                            q_ptr,
+                            k_ptr,
+                            cos_ptr,
+                            sin_ptr,
+                            pos_ptr,
+                            q_bh,
+                            k_bh,
+                            seq_len_u32,
+                            d_u32,
+                            stream,
                         );
                     }
                 }
             }
-            _ => candle_core::bail!(
-                "FusedRope only supports F32, F16, and BF16 dtypes, got {:?}",
-                dtype
-            ),
+            _ => candle_core::bail!("FusedRope only supports F32, F16, BF16, got {:?}", dtype),
         }
 
         Ok(())
     }
 
-    /// Convenience method for non-interleaved rotary embedding
+    /// Convenience: non-interleaved RoPE
     #[cfg(feature = "cuda")]
     pub fn apply_rope(
         q: &Tensor,
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
-        Self::apply(q, k, cos, sin, false)
+        Self::apply(q, k, cos, sin, positions, false)
     }
 
-    /// Convenience method for interleaved rotary embedding
+    /// Convenience: interleaved RoPE
     #[cfg(feature = "cuda")]
     pub fn apply_rope_i(
         q: &Tensor,
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
-        Self::apply(q, k, cos, sin, true)
+        Self::apply(q, k, cos, sin, positions, true)
     }
 
-    /// Convenience method for non-interleaved rotary embedding (in-place)
+    /// Convenience: non-interleaved RoPE in-place
     #[cfg(feature = "cuda")]
     pub fn apply_rope_inplace(
         q: &Tensor,
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
     ) -> Result<()> {
-        Self::apply_inplace(q, k, cos, sin, false)
+        Self::apply_inplace(q, k, cos, sin, positions, false)
     }
 
-    /// Convenience method for interleaved rotary embedding (in-place)
+    /// Convenience: interleaved RoPE in-place
     #[cfg(feature = "cuda")]
     pub fn apply_rope_i_inplace(
         q: &Tensor,
         k: &Tensor,
         cos: &Tensor,
         sin: &Tensor,
+        positions: &Tensor,
     ) -> Result<()> {
-        Self::apply_inplace(q, k, cos, sin, true)
+        Self::apply_inplace(q, k, cos, sin, positions, true)
     }
 }

--- a/src/fused_rope.rs
+++ b/src/fused_rope.rs
@@ -124,12 +124,10 @@ impl FusedRope {
         let d_u32 = d as u32;
 
         // Clone for output
-        let q_out = q.clone();
-        let k_out = k.clone();
 
         // Get storage
-        let q_out_storage = q_out.storage_and_layout().0;
-        let k_out_storage = k_out.storage_and_layout().0;
+        let q_out_storage = q.storage_and_layout().0;
+        let k_out_storage = k.storage_and_layout().0;
         let cos_storage = cos.storage_and_layout().0;
         let sin_storage = sin.storage_and_layout().0;
         let pos_storage = positions.storage_and_layout().0;
@@ -309,7 +307,7 @@ impl FusedRope {
             _ => candle_core::bail!("FusedRope only supports F32, F16, BF16, got {:?}", dtype),
         }
 
-        Ok((q_out, k_out))
+        Ok((q.to_owned(), k.to_owned()))
     }
 
     /// Apply fused rotary embedding in-place.

--- a/src/fused_rope.rs
+++ b/src/fused_rope.rs
@@ -257,6 +257,212 @@ impl FusedRope {
         Ok((q_out, k_out))
     }
 
+    /// Apply fused rotary embedding to Q and K tensors truly in-place.
+    /// This modifies the input tensors directly and returns Result<()>.
+    ///
+    /// # Arguments
+    /// * `q` - Query tensor, shape [batch, num_heads, seq_len, head_dim] (modified in-place)
+    /// * `k` - Key tensor, shape [batch, num_heads, seq_len, head_dim] (modified in-place)
+    /// * `cos` - Cosine values, shape [seq_len, head_dim/2]
+    /// * `sin` - Sine values, shape [seq_len, head_dim/2]
+    /// * `is_interleaved` - If true, uses interleaved layout (adjacent pairs)
+    ///
+    /// # Returns
+    /// Result<()> indicating success or failure
+    #[cfg(feature = "cuda")]
+    pub fn apply_inplace(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        is_interleaved: bool,
+    ) -> Result<()> {
+        use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+        use candle_core::cuda_backend::CudaStorageSlice;
+
+        // Validate inputs
+        let (b, h, t, d) = q.dims4()?;
+        let (kb, kh, kt, kd) = k.dims4()?;
+
+        if (b, h, t, d) != (kb, kh, kt, kd) {
+            candle_core::bail!(
+                "Q and K shapes must match, got Q: {:?}, K: {:?}",
+                q.shape(),
+                k.shape()
+            );
+        }
+
+        // Check cos/sin dimensions
+        let cos_shape = cos.dims();
+        let sin_shape = sin.dims();
+
+        if cos_shape != sin_shape {
+            candle_core::bail!(
+                "cos and sin shapes must match, got cos: {:?}, sin: {:?}",
+                cos_shape,
+                sin_shape
+            );
+        }
+
+        // Tensors should already be contiguous for in-place ops
+        if !q.is_contiguous() {
+            candle_core::bail!("Q must be contiguous for in-place operation");
+        }
+        if !k.is_contiguous() {
+            candle_core::bail!("K must be contiguous for in-place operation");
+        }
+        if !cos.is_contiguous() {
+            candle_core::bail!("cos must be contiguous for in-place operation");
+        }
+        if !sin.is_contiguous() {
+            candle_core::bail!("sin must be contiguous for in-place operation");
+        }
+
+        // Validate dtypes match
+        let dtype = q.dtype();
+        if k.dtype() != dtype || cos.dtype() != dtype || sin.dtype() != dtype {
+            candle_core::bail!(
+                "All tensors must have the same dtype, got Q: {:?}, K: {:?}, cos: {:?}, sin: {:?}",
+                q.dtype(),
+                k.dtype(),
+                cos.dtype(),
+                sin.dtype()
+            );
+        }
+
+        // Get device
+        let dev = q.device().as_cuda_device()?;
+        let stream = *dev.cu_stream() as i64;
+
+        // Calculate kernel parameters
+        let bh = (b * h) as u32;
+        let td = (t * d) as u32;
+        let d_param = d as u32;
+        let stride_b = 0u32;
+
+        // Get storage - directly use input tensors (in-place)
+        let q_storage = q.storage_and_layout().0;
+        let k_storage = k.storage_and_layout().0;
+        let cos_storage = cos.storage_and_layout().0;
+        let sin_storage = sin.storage_and_layout().0;
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("Q must be on CUDA device"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("K must be on CUDA device"),
+        };
+        let cos_cuda = match &*cos_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("cos must be on CUDA device"),
+        };
+        let sin_cuda = match &*sin_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("sin must be on CUDA device"),
+        };
+
+        match dtype {
+            DType::F32 => {
+                let q_ptr = match &q_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let k_ptr = match &k_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_f32(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_f32(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            DType::F16 => {
+                let q_ptr = match &q_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let k_ptr = match &k_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_f16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_f16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            DType::BF16 => {
+                let q_ptr = match &q_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let k_ptr = match &k_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_bf16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_bf16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            _ => candle_core::bail!(
+                "FusedRope only supports F32, F16, and BF16 dtypes, got {:?}",
+                dtype
+            ),
+        }
+
+        Ok(())
+    }
+
     /// Convenience method for non-interleaved rotary embedding
     #[cfg(feature = "cuda")]
     pub fn apply_rope(
@@ -277,5 +483,27 @@ impl FusedRope {
         sin: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
         Self::apply(q, k, cos, sin, true)
+    }
+
+    /// Convenience method for non-interleaved rotary embedding (in-place)
+    #[cfg(feature = "cuda")]
+    pub fn apply_rope_inplace(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<()> {
+        Self::apply_inplace(q, k, cos, sin, false)
+    }
+
+    /// Convenience method for interleaved rotary embedding (in-place)
+    #[cfg(feature = "cuda")]
+    pub fn apply_rope_i_inplace(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<()> {
+        Self::apply_inplace(q, k, cos, sin, true)
     }
 }

--- a/src/fused_rope.rs
+++ b/src/fused_rope.rs
@@ -1,0 +1,281 @@
+//! Fused Rotary Position Embedding (RoPE) CUDA kernel interface
+//!
+//! This module provides a high-performance fused rotary embedding implementation
+//! that operates on both Q and K tensors simultaneously in-place.
+
+use candle_core::{DType, Result, Tensor};
+
+#[cfg(feature = "cuda")]
+use kernels::ffi;
+
+/// Fused Rotary Position Embedding
+///
+/// Applies rotary position embedding to Q and K tensors in-place using optimized CUDA kernels.
+/// Supports both interleaved and non-interleaved layouts.
+pub struct FusedRope;
+
+impl FusedRope {
+    /// Apply fused rotary embedding to Q and K tensors in-place.
+    ///
+    /// # Arguments
+    /// * `q` - Query tensor, shape [batch, num_heads, seq_len, head_dim]
+    /// * `k` - Key tensor, shape [batch, num_heads, seq_len, head_dim]
+    /// * `cos` - Cosine values, shape [seq_len, head_dim/2]
+    /// * `sin` - Sine values, shape [seq_len, head_dim/2]
+    /// * `is_interleaved` - If true, uses interleaved layout (adjacent pairs)
+    ///
+    /// # Returns
+    /// Result with (q_embed, k_embed) tensors with rotary embedding applied
+    #[cfg(feature = "cuda")]
+    pub fn apply(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        is_interleaved: bool,
+    ) -> Result<(Tensor, Tensor)> {
+        use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+        use candle_core::cuda_backend::CudaStorageSlice;
+
+        // Validate inputs
+        let (b, h, t, d) = q.dims4()?;
+        let (kb, kh, kt, kd) = k.dims4()?;
+
+        if (b, h, t, d) != (kb, kh, kt, kd) {
+            candle_core::bail!(
+                "Q and K shapes must match, got Q: {:?}, K: {:?}",
+                q.shape(),
+                k.shape()
+            );
+        }
+
+        // Check cos/sin dimensions
+        let cos_shape = cos.dims();
+        let sin_shape = sin.dims();
+
+        if cos_shape != sin_shape {
+            candle_core::bail!(
+                "cos and sin shapes must match, got cos: {:?}, sin: {:?}",
+                cos_shape,
+                sin_shape
+            );
+        }
+
+        // cos/sin should be [seq_len, head_dim/2] or similar
+        let expected_last_dim = d / 2;
+        if cos_shape.len() < 1 || cos_shape[cos_shape.len() - 1] != expected_last_dim {
+            candle_core::bail!(
+                "cos/sin last dimension should be {}, got {:?}",
+                expected_last_dim,
+                cos_shape
+            );
+        }
+
+        // Ensure contiguity
+        let q = if !q.is_contiguous() {
+            q.contiguous()?
+        } else {
+            q.clone()
+        };
+        let k = if !k.is_contiguous() {
+            k.contiguous()?
+        } else {
+            k.clone()
+        };
+        let cos = if !cos.is_contiguous() {
+            cos.contiguous()?
+        } else {
+            cos.clone()
+        };
+        let sin = if !sin.is_contiguous() {
+            sin.contiguous()?
+        } else {
+            sin.clone()
+        };
+
+        // Validate dtypes match
+        let dtype = q.dtype();
+        if k.dtype() != dtype || cos.dtype() != dtype || sin.dtype() != dtype {
+            candle_core::bail!(
+                "All tensors must have the same dtype, got Q: {:?}, K: {:?}, cos: {:?}, sin: {:?}",
+                q.dtype(),
+                k.dtype(),
+                cos.dtype(),
+                sin.dtype()
+            );
+        }
+
+        // Get device
+        let dev = q.device().as_cuda_device()?;
+        let stream = *dev.cu_stream() as i64;
+
+        // Calculate kernel parameters
+        let bh = (b * h) as u32;
+        let td = (t * d) as u32;
+        let d_param = d as u32;
+        let stride_b = 0u32; // No batch stride for now (shared cos/sin across batch)
+
+        // Get storage and call appropriate kernel
+        let q_storage = q.storage_and_layout().0;
+        let k_storage = k.storage_and_layout().0;
+        let cos_storage = cos.storage_and_layout().0;
+        let sin_storage = sin.storage_and_layout().0;
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("Q must be on CUDA device"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("K must be on CUDA device"),
+        };
+        let cos_cuda = match &*cos_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("cos must be on CUDA device"),
+        };
+        let sin_cuda = match &*sin_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("sin must be on CUDA device"),
+        };
+
+        // Note: The kernel operates in-place on q and k
+        // We need to clone them first to avoid modifying the originals
+        // unless we explicitly want in-place operation
+        let q_out = q.clone();
+        let k_out = k.clone();
+
+        // Get mutable storage for output
+        let q_out_storage = q_out.storage_and_layout().0;
+        let k_out_storage = k_out.storage_and_layout().0;
+
+        let q_out_cuda = match &*q_out_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("Q output must be on CUDA device"),
+        };
+        let k_out_cuda = match &*k_out_storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("K output must be on CUDA device"),
+        };
+
+        match dtype {
+            DType::F32 => {
+                let q_ptr = match &q_out_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let k_ptr = match &k_out_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *mut f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::F32(s) => *s.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Expected F32 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_f32(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_f32(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            DType::F16 => {
+                let q_ptr = match &q_out_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let k_ptr = match &k_out_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::F16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected F16 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_f16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_f16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            DType::BF16 => {
+                let q_ptr = match &q_out_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let k_ptr = match &k_out_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *mut core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let cos_ptr = match &cos_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+                let sin_ptr = match &sin_cuda.slice {
+                    CudaStorageSlice::BF16(s) => *s.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Expected BF16 storage"),
+                };
+
+                unsafe {
+                    if is_interleaved {
+                        ffi::fused_rope_i_bf16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, stride_b, stream,
+                        );
+                    } else {
+                        ffi::fused_rope_bf16(
+                            q_ptr, k_ptr, cos_ptr, sin_ptr, bh, td, d_param, stride_b, stream,
+                        );
+                    }
+                }
+            }
+            _ => candle_core::bail!(
+                "FusedRope only supports F32, F16, and BF16 dtypes, got {:?}",
+                dtype
+            ),
+        }
+
+        Ok((q_out, k_out))
+    }
+
+    /// Convenience method for non-interleaved rotary embedding
+    #[cfg(feature = "cuda")]
+    pub fn apply_rope(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        Self::apply(q, k, cos, sin, false)
+    }
+
+    /// Convenience method for interleaved rotary embedding
+    #[cfg(feature = "cuda")]
+    pub fn apply_rope_i(
+        q: &Tensor,
+        k: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        Self::apply(q, k, cos, sin, true)
+    }
+}

--- a/src/kernels/build.rs
+++ b/src/kernels/build.rs
@@ -16,6 +16,7 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=src/moe_wmma_gguf.cu");
     println!("cargo:rerun-if-changed=src/gpu_sampling.cuh");
     println!("cargo:rerun-if-changed=src/gpu_sampling.cu");
+    println!("cargo:rerun-if-changed=src/fused_rope.cu");
     let marlin_disabled = std::env::var("CARGO_FEATURE_NO_MARLIN").is_ok();
     let fp8_kvcache_disabled = std::env::var("CARGO_FEATURE_NO_FP8_KVCACHE").is_ok();
     let build_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap_or("".to_string()));

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -531,13 +531,14 @@ extern "C" {
     );
 
     // Fused Rotary Position Embedding (RoPE) kernels
-    // Non-interleaved versions
+    // Non-interleaved versions - support GQA with separate q_bh and k_bh
     pub fn fused_rope_f32(
         q: *mut f32,
         k: *mut f32,
         cos: *const f32,
         sin: *const f32,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         d: u32,
         stride_b: u32,
@@ -549,7 +550,8 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         d: u32,
         stride_b: u32,
@@ -561,20 +563,22 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         d: u32,
         stride_b: u32,
         stream: i64,
     );
 
-    // Interleaved versions
+    // Interleaved versions - support GQA with separate q_bh and k_bh
     pub fn fused_rope_i_f32(
         q: *mut f32,
         k: *mut f32,
         cos: *const f32,
         sin: *const f32,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         stride_b: u32,
         stream: i64,
@@ -585,7 +589,8 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         stride_b: u32,
         stream: i64,
@@ -596,7 +601,8 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
-        bh: u32,
+        q_bh: u32,
+        k_bh: u32,
         td: u32,
         stride_b: u32,
         stream: i64,

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -530,18 +530,18 @@ extern "C" {
         stream: i64,
     );
 
-    // Fused Rotary Position Embedding (RoPE) kernels
-    // Non-interleaved versions - support GQA with separate q_bh and k_bh
+    // Fused Rotary Position Embedding (RoPE) kernels - with position selection
+    // Non-interleaved versions - support GQA, fuses index_select
     pub fn fused_rope_f32(
         q: *mut f32,
         k: *mut f32,
         cos: *const f32,
         sin: *const f32,
+        positions: *const i64, // Position indices [seq_len]
         q_bh: u32,
         k_bh: u32,
-        td: u32,
+        seq_len: u32,
         d: u32,
-        stride_b: u32,
         stream: i64,
     );
 
@@ -550,11 +550,11 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
+        positions: *const i64,
         q_bh: u32,
         k_bh: u32,
-        td: u32,
+        seq_len: u32,
         d: u32,
-        stride_b: u32,
         stream: i64,
     );
 
@@ -563,24 +563,25 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
+        positions: *const i64,
         q_bh: u32,
         k_bh: u32,
-        td: u32,
+        seq_len: u32,
         d: u32,
-        stride_b: u32,
         stream: i64,
     );
 
-    // Interleaved versions - support GQA with separate q_bh and k_bh
+    // Interleaved versions - support GQA, fuses index_select
     pub fn fused_rope_i_f32(
         q: *mut f32,
         k: *mut f32,
         cos: *const f32,
         sin: *const f32,
+        positions: *const i64,
         q_bh: u32,
         k_bh: u32,
-        td: u32,
-        stride_b: u32,
+        seq_len: u32,
+        d: u32,
         stream: i64,
     );
 
@@ -589,10 +590,11 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
+        positions: *const i64,
         q_bh: u32,
         k_bh: u32,
-        td: u32,
-        stride_b: u32,
+        seq_len: u32,
+        d: u32,
         stream: i64,
     );
 
@@ -601,10 +603,11 @@ extern "C" {
         k: *mut c_void,
         cos: *const c_void,
         sin: *const c_void,
+        positions: *const i64,
         q_bh: u32,
         k_bh: u32,
-        td: u32,
-        stride_b: u32,
+        seq_len: u32,
+        d: u32,
         stream: i64,
     );
 }

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -529,4 +529,76 @@ extern "C" {
         token_pos: u64,
         stream: i64,
     );
+
+    // Fused Rotary Position Embedding (RoPE) kernels
+    // Non-interleaved versions
+    pub fn fused_rope_f32(
+        q: *mut f32,
+        k: *mut f32,
+        cos: *const f32,
+        sin: *const f32,
+        bh: u32,
+        td: u32,
+        d: u32,
+        stride_b: u32,
+        stream: i64,
+    );
+
+    pub fn fused_rope_f16(
+        q: *mut c_void,
+        k: *mut c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        bh: u32,
+        td: u32,
+        d: u32,
+        stride_b: u32,
+        stream: i64,
+    );
+
+    pub fn fused_rope_bf16(
+        q: *mut c_void,
+        k: *mut c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        bh: u32,
+        td: u32,
+        d: u32,
+        stride_b: u32,
+        stream: i64,
+    );
+
+    // Interleaved versions
+    pub fn fused_rope_i_f32(
+        q: *mut f32,
+        k: *mut f32,
+        cos: *const f32,
+        sin: *const f32,
+        bh: u32,
+        td: u32,
+        stride_b: u32,
+        stream: i64,
+    );
+
+    pub fn fused_rope_i_f16(
+        q: *mut c_void,
+        k: *mut c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        bh: u32,
+        td: u32,
+        stride_b: u32,
+        stream: i64,
+    );
+
+    pub fn fused_rope_i_bf16(
+        q: *mut c_void,
+        k: *mut c_void,
+        cos: *const c_void,
+        sin: *const c_void,
+        bh: u32,
+        td: u32,
+        stride_b: u32,
+        stream: i64,
+    );
 }

--- a/src/kernels/src/fused_rope.cu
+++ b/src/kernels/src/fused_rope.cu
@@ -1,0 +1,497 @@
+/**
+ * @brief Fused Rotary Position Embedding (RoPE) CUDA Kernels - Highly Optimized
+ * Copyright (c) 2025, Guoqing Bao. All rights reserved.
+ *
+ * This kernel performs fused rotary position embedding on Q and K tensors in-place:
+ *  - fused_rope: Non-interleaved version (pairs at offset d/2)
+ *  - fused_rope_i: Interleaved version (adjacent pairs)
+ *
+ * Optimizations:
+ *  - Vectorized load/store AND compute (half2, bfloat162, float2)
+ *  - Native compute: F32 and BF16 compute natively, only F16 converts to F32
+ *  - Shared memory for cos/sin caching to reduce global memory traffic
+ *  - Single kernel launch for both Q and K (reduces launch overhead)
+ *  - In-place operation (reduces memory allocation/bandwidth)
+ *
+ * Licensed under the Apache License, Version 2.0
+ */
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <stdint.h>
+
+// Block configuration
+constexpr int BLOCK_SIZE = 256;
+
+// ============================================================================
+// Vectorized Types and Operations for Native Compute
+// ============================================================================
+
+// --- float2 native operations (F32 computes natively) ---
+__device__ __forceinline__ float2 make_float2_from(float x, float y) {
+    return make_float2(x, y);
+}
+
+__device__ __forceinline__ float2 rope_rotate_f32(float2 v, float c, float s) {
+    // Native float compute
+    float2 result;
+    result.x = v.x * c - v.y * s;
+    result.y = v.x * s + v.y * c;
+    return result;
+}
+
+// --- __nv_bfloat162 native operations (BF16 computes natively) ---
+#ifndef NO_BF16_KERNEL
+__device__ __forceinline__ __nv_bfloat162 rope_rotate_bf16(__nv_bfloat162 v, __nv_bfloat16 c, __nv_bfloat16 s) {
+    // Native bfloat16 compute using intrinsics
+    __nv_bfloat162 c2 = __bfloat162bfloat162(c);
+    __nv_bfloat162 s2 = __bfloat162bfloat162(s);
+    
+    // v.x * c - v.y * s, v.x * s + v.y * c
+    __nv_bfloat162 vx = __bfloat162bfloat162(v.x);  // (v.x, v.x)
+    __nv_bfloat162 vy = __bfloat162bfloat162(v.y);  // (v.y, v.y)
+    
+    // Compute: (v.x * c, v.x * s)
+    __nv_bfloat162 cs = {c, s};
+    __nv_bfloat162 term1 = __hmul2(vx, cs);
+    
+    // Compute: (v.y * s, v.y * c)
+    __nv_bfloat162 sc = {s, c};
+    __nv_bfloat162 term2 = __hmul2(vy, sc);
+    
+    // result.x = term1.x - term2.x, result.y = term1.y + term2.y
+    __nv_bfloat162 result;
+    result.x = __hsub(term1.x, term2.x);
+    result.y = __hadd(term1.y, term2.y);
+    
+    return result;
+}
+#endif
+
+// --- __half2 operations (F16 converts to F32 for precision) ---
+__device__ __forceinline__ __half2 rope_rotate_f16(__half2 v, __half c, __half s) {
+    // Convert to float for precise computation
+    float vx = __half2float(v.x);
+    float vy = __half2float(v.y);
+    float fc = __half2float(c);
+    float fs = __half2float(s);
+    
+    __half2 result;
+    result.x = __float2half(vx * fc - vy * fs);
+    result.y = __float2half(vx * fs + vy * fc);
+    return result;
+}
+
+// ============================================================================
+// Interleaved Fused RoPE - Vectorized Load/Store AND Compute
+// ============================================================================
+
+/**
+ * @brief F32 Interleaved kernel - fully native vectorized compute
+ */
+__global__ void fused_rope_i_f32_kernel(
+    float2* __restrict__ q,  // Treat as float2 for vectorized access
+    float2* __restrict__ k,
+    const float* __restrict__ cos,
+    const float* __restrict__ sin,
+    const uint32_t num_pairs,  // (bh * td) / 2
+    const uint32_t half_td,
+    const uint32_t stride_b
+) {
+    __shared__ float s_cos[BLOCK_SIZE];
+    __shared__ float s_sin[BLOCK_SIZE];
+
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= num_pairs) return;
+
+    // Calculate cos/sin index
+    uint32_t rope_idx = idx % half_td;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        rope_idx += b_idx * half_td;
+    }
+
+    // Load cos/sin into shared memory
+    s_cos[threadIdx.x] = cos[rope_idx];
+    s_sin[threadIdx.x] = sin[rope_idx];
+    __syncthreads();
+
+    float c = s_cos[threadIdx.x];
+    float s = s_sin[threadIdx.x];
+
+    // Vectorized load, native compute, vectorized store for Q
+    float2 q_vec = q[idx];
+    q[idx] = rope_rotate_f32(q_vec, c, s);
+
+    // Same for K
+    float2 k_vec = k[idx];
+    k[idx] = rope_rotate_f32(k_vec, c, s);
+}
+
+/**
+ * @brief F16 Interleaved kernel - vectorized load/store, float compute for precision
+ */
+__global__ void fused_rope_i_f16_kernel(
+    __half2* __restrict__ q,
+    __half2* __restrict__ k,
+    const __half* __restrict__ cos,
+    const __half* __restrict__ sin,
+    const uint32_t num_pairs,
+    const uint32_t half_td,
+    const uint32_t stride_b
+) {
+    __shared__ __half s_cos[BLOCK_SIZE];
+    __shared__ __half s_sin[BLOCK_SIZE];
+
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= num_pairs) return;
+
+    uint32_t rope_idx = idx % half_td;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        rope_idx += b_idx * half_td;
+    }
+
+    s_cos[threadIdx.x] = cos[rope_idx];
+    s_sin[threadIdx.x] = sin[rope_idx];
+    __syncthreads();
+
+    __half c = s_cos[threadIdx.x];
+    __half s = s_sin[threadIdx.x];
+
+    // Vectorized load, F32 compute (for precision), vectorized store
+    __half2 q_vec = q[idx];
+    q[idx] = rope_rotate_f16(q_vec, c, s);
+
+    __half2 k_vec = k[idx];
+    k[idx] = rope_rotate_f16(k_vec, c, s);
+}
+
+#ifndef NO_BF16_KERNEL
+/**
+ * @brief BF16 Interleaved kernel - fully native vectorized compute
+ */
+__global__ void fused_rope_i_bf16_kernel(
+    __nv_bfloat162* __restrict__ q,
+    __nv_bfloat162* __restrict__ k,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    const uint32_t num_pairs,
+    const uint32_t half_td,
+    const uint32_t stride_b
+) {
+    __shared__ __nv_bfloat16 s_cos[BLOCK_SIZE];
+    __shared__ __nv_bfloat16 s_sin[BLOCK_SIZE];
+
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= num_pairs) return;
+
+    uint32_t rope_idx = idx % half_td;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        rope_idx += b_idx * half_td;
+    }
+
+    s_cos[threadIdx.x] = cos[rope_idx];
+    s_sin[threadIdx.x] = sin[rope_idx];
+    __syncthreads();
+
+    __nv_bfloat16 c = s_cos[threadIdx.x];
+    __nv_bfloat16 s = s_sin[threadIdx.x];
+
+    // Vectorized load, native BF16 compute, vectorized store
+    __nv_bfloat162 q_vec = q[idx];
+    q[idx] = rope_rotate_bf16(q_vec, c, s);
+
+    __nv_bfloat162 k_vec = k[idx];
+    k[idx] = rope_rotate_bf16(k_vec, c, s);
+}
+#endif
+
+// ============================================================================
+// Non-Interleaved Fused RoPE - Native Compute with Shared Memory
+// ============================================================================
+
+/**
+ * @brief F32 Non-interleaved kernel - native float compute
+ */
+__global__ void fused_rope_f32_kernel(
+    float* __restrict__ q,
+    float* __restrict__ k,
+    const float* __restrict__ cos,
+    const float* __restrict__ sin,
+    const uint32_t bh,
+    const uint32_t td,
+    const uint32_t d,
+    const uint32_t stride_b
+) {
+    __shared__ float s_cos[BLOCK_SIZE];
+    __shared__ float s_sin[BLOCK_SIZE];
+
+    const uint32_t total_pairs = (bh * td) / 2;
+    const uint32_t half_d = d / 2;
+    const uint32_t half_td = td / 2;
+    
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_pairs) return;
+
+    // Calculate indices for non-interleaved layout
+    uint32_t i_bh = idx / half_td;
+    uint32_t i_td = idx - half_td * i_bh;
+    uint32_t i_t = i_td / half_d;
+    uint32_t i_d = i_td - half_d * i_t;
+    
+    uint32_t i1 = i_bh * td + i_t * d + i_d;
+    uint32_t i2 = i1 + half_d;
+    
+    uint32_t i_cs = i_t * half_d + i_d;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        i_cs += b_idx * half_td;
+    }
+
+    s_cos[threadIdx.x] = cos[i_cs];
+    s_sin[threadIdx.x] = sin[i_cs];
+    __syncthreads();
+
+    float c = s_cos[threadIdx.x];
+    float s = s_sin[threadIdx.x];
+
+    // Native float compute for Q
+    float q1 = q[i1];
+    float q2 = q[i2];
+    q[i1] = q1 * c - q2 * s;
+    q[i2] = q1 * s + q2 * c;
+
+    // Native float compute for K
+    float k1 = k[i1];
+    float k2 = k[i2];
+    k[i1] = k1 * c - k2 * s;
+    k[i2] = k1 * s + k2 * c;
+}
+
+/**
+ * @brief F16 Non-interleaved kernel - F32 compute for precision
+ */
+__global__ void fused_rope_f16_kernel(
+    __half* __restrict__ q,
+    __half* __restrict__ k,
+    const __half* __restrict__ cos,
+    const __half* __restrict__ sin,
+    const uint32_t bh,
+    const uint32_t td,
+    const uint32_t d,
+    const uint32_t stride_b
+) {
+    __shared__ float s_cos[BLOCK_SIZE];
+    __shared__ float s_sin[BLOCK_SIZE];
+
+    const uint32_t total_pairs = (bh * td) / 2;
+    const uint32_t half_d = d / 2;
+    const uint32_t half_td = td / 2;
+    
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_pairs) return;
+
+    uint32_t i_bh = idx / half_td;
+    uint32_t i_td = idx - half_td * i_bh;
+    uint32_t i_t = i_td / half_d;
+    uint32_t i_d = i_td - half_d * i_t;
+    
+    uint32_t i1 = i_bh * td + i_t * d + i_d;
+    uint32_t i2 = i1 + half_d;
+    
+    uint32_t i_cs = i_t * half_d + i_d;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        i_cs += b_idx * half_td;
+    }
+
+    // Convert cos/sin to F32 once
+    s_cos[threadIdx.x] = __half2float(cos[i_cs]);
+    s_sin[threadIdx.x] = __half2float(sin[i_cs]);
+    __syncthreads();
+
+    float c = s_cos[threadIdx.x];
+    float s = s_sin[threadIdx.x];
+
+    // F32 compute for precision, then convert back
+    float q1 = __half2float(q[i1]);
+    float q2 = __half2float(q[i2]);
+    q[i1] = __float2half(q1 * c - q2 * s);
+    q[i2] = __float2half(q1 * s + q2 * c);
+
+    float k1 = __half2float(k[i1]);
+    float k2 = __half2float(k[i2]);
+    k[i1] = __float2half(k1 * c - k2 * s);
+    k[i2] = __float2half(k1 * s + k2 * c);
+}
+
+#ifndef NO_BF16_KERNEL
+/**
+ * @brief BF16 Non-interleaved kernel - native BF16 compute
+ */
+__global__ void fused_rope_bf16_kernel(
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    const uint32_t bh,
+    const uint32_t td,
+    const uint32_t d,
+    const uint32_t stride_b
+) {
+    __shared__ __nv_bfloat16 s_cos[BLOCK_SIZE];
+    __shared__ __nv_bfloat16 s_sin[BLOCK_SIZE];
+
+    const uint32_t total_pairs = (bh * td) / 2;
+    const uint32_t half_d = d / 2;
+    const uint32_t half_td = td / 2;
+    
+    const uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_pairs) return;
+
+    uint32_t i_bh = idx / half_td;
+    uint32_t i_td = idx - half_td * i_bh;
+    uint32_t i_t = i_td / half_d;
+    uint32_t i_d = i_td - half_d * i_t;
+    
+    uint32_t i1 = i_bh * td + i_t * d + i_d;
+    uint32_t i2 = i1 + half_d;
+    
+    uint32_t i_cs = i_t * half_d + i_d;
+    if (stride_b > 0) {
+        uint32_t b_idx = (2 * idx) / stride_b;
+        i_cs += b_idx * half_td;
+    }
+
+    s_cos[threadIdx.x] = cos[i_cs];
+    s_sin[threadIdx.x] = sin[i_cs];
+    __syncthreads();
+
+    __nv_bfloat16 c = s_cos[threadIdx.x];
+    __nv_bfloat16 s = s_sin[threadIdx.x];
+
+    // Native BF16 compute using intrinsics
+    __nv_bfloat16 q1 = q[i1];
+    __nv_bfloat16 q2 = q[i2];
+    q[i1] = __hsub(__hmul(q1, c), __hmul(q2, s));
+    q[i2] = __hadd(__hmul(q1, s), __hmul(q2, c));
+
+    __nv_bfloat16 k1 = k[i1];
+    __nv_bfloat16 k2 = k[i2];
+    k[i1] = __hsub(__hmul(k1, c), __hmul(k2, s));
+    k[i2] = __hadd(__hmul(k1, s), __hmul(k2, c));
+}
+#endif
+
+// ============================================================================
+// Launch configuration helper
+// ============================================================================
+
+inline dim3 get_launch_config(uint32_t num_elements) {
+    int num_blocks = (num_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    return dim3(num_blocks, 1, 1);
+}
+
+// ============================================================================
+// C-linkage wrapper functions for FFI
+// ============================================================================
+
+// Non-interleaved versions
+extern "C" void fused_rope_f32(
+    float* q, float* k,
+    const float* cos, const float* sin,
+    uint32_t bh, uint32_t td, uint32_t d, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_f32_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(q, k, cos, sin, bh, td, d, stride_b);
+}
+
+extern "C" void fused_rope_f16(
+    void* q, void* k,
+    const void* cos, const void* sin,
+    uint32_t bh, uint32_t td, uint32_t d, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_f16_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(
+        (__half*)q, (__half*)k, (const __half*)cos, (const __half*)sin, 
+        bh, td, d, stride_b
+    );
+}
+
+#ifndef NO_BF16_KERNEL
+extern "C" void fused_rope_bf16(
+    void* q, void* k,
+    const void* cos, const void* sin,
+    uint32_t bh, uint32_t td, uint32_t d, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_bf16_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(
+        (__nv_bfloat16*)q, (__nv_bfloat16*)k, 
+        (const __nv_bfloat16*)cos, (const __nv_bfloat16*)sin, 
+        bh, td, d, stride_b
+    );
+}
+#endif
+
+// Interleaved versions - use vectorized types (float2, half2, bfloat162)
+extern "C" void fused_rope_i_f32(
+    float* q, float* k,
+    const float* cos, const float* sin,
+    uint32_t bh, uint32_t td, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    uint32_t half_td = td / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_i_f32_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(
+        (float2*)q, (float2*)k, cos, sin, num_pairs, half_td, stride_b
+    );
+}
+
+extern "C" void fused_rope_i_f16(
+    void* q, void* k,
+    const void* cos, const void* sin,
+    uint32_t bh, uint32_t td, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    uint32_t half_td = td / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_i_f16_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(
+        (__half2*)q, (__half2*)k, (const __half*)cos, (const __half*)sin, 
+        num_pairs, half_td, stride_b
+    );
+}
+
+#ifndef NO_BF16_KERNEL
+extern "C" void fused_rope_i_bf16(
+    void* q, void* k,
+    const void* cos, const void* sin,
+    uint32_t bh, uint32_t td, uint32_t stride_b,
+    int64_t stream_ptr
+) {
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    uint32_t num_pairs = (bh * td) / 2;
+    uint32_t half_td = td / 2;
+    dim3 grid = get_launch_config(num_pairs);
+    fused_rope_i_bf16_kernel<<<grid, BLOCK_SIZE, 0, stream>>>(
+        (__nv_bfloat162*)q, (__nv_bfloat162*)k, 
+        (const __nv_bfloat16*)cos, (const __nv_bfloat16*)sin, 
+        num_pairs, half_td, stride_b
+    );
+}
+#endif

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ pub mod scale_update;
 use candle_core::{Device, Result, Tensor};
 use paged_attention::{paged_attention, reshape_and_cache};
 use scale_update::kv_scale_update;
-#[cfg(feature = "cuda")]
 pub mod fused_rope;
 pub mod mask;
 #[cfg(feature = "cuda")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod scale_update;
 use candle_core::{Device, Result, Tensor};
 use paged_attention::{paged_attention, reshape_and_cache};
 use scale_update::kv_scale_update;
+#[cfg(feature = "cuda")]
+pub mod fused_rope;
 pub mod mask;
 #[cfg(feature = "cuda")]
 pub mod sampler;

--- a/src/metal-kernels/build.rs
+++ b/src/metal-kernels/build.rs
@@ -1,13 +1,14 @@
 use std::path::PathBuf;
 use std::process::Command;
 use std::{env, str};
-const METAL_SOURCES: [&str; 6] = [
+const METAL_SOURCES: [&str; 7] = [
     "copy_blocks",
     "pagedattention",
     "reshape_and_cache",
     "prefill_paged_attn",
     "mask",
     "update_scales",
+    "fused_rope",
 ];
 
 enum Platform {

--- a/src/metal-kernels/src/fused_rope.metal
+++ b/src/metal-kernels/src/fused_rope.metal
@@ -1,0 +1,308 @@
+/**
+ * @brief Fused Rotary Position Embedding (RoPE) Metal Kernels - With Position Selection
+ * Copyright (c) 2025, Guoqingbao. All rights reserved.
+ *
+ * This kernel fuses TWO operations:
+ *   1. Position-based cos/sin selection (eliminates index_select kernel)
+ *   2. Rotary position embedding application
+ *
+ * Performance optimizations:
+ *  - Native BF16/F32 compute, F16 -> F32 for precision (matches CUDA)
+ *  - Vectorized pair operations using half2/Bfloat2_ (like CUDA's __half2/__bfloat162)
+ *  - Single kernel for Q+K
+ *  - GQA support (different Q/K head counts)
+ *
+ * Supports both interleaved and non-interleaved RoPE layouts.
+ *
+ * Licensed under the Apache License, Version 2.0
+ */
+
+#include "metal_dtype.metal"
+#include <metal_stdlib>
+using namespace metal;
+
+// ============================================================================
+// Interleaved RoPE with Position Selection
+// Adjacent pairs: (x0, x1), (x2, x3), ...
+// Uses vectorized access like CUDA's float2/half2/bfloat162
+// ============================================================================
+
+// F32 interleaved - uses float2 for vectorized pair access
+kernel void fused_rope_i_f32(
+    device float2* q [[buffer(0)]],      // Access as pairs
+    device float2* k [[buffer(1)]],
+    constant float* cos [[buffer(2)]],
+    constant float* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_num_pairs = q_bh * seq_len * half_d;
+    const uint k_num_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_num_pairs + k_num_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_num_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_num_pairs);
+    
+    const uint d_idx = local_idx % half_d;
+    const uint t_idx = (local_idx / half_d) % seq_len;
+    
+    const long pos = positions[t_idx];
+    const uint cs_idx = pos * half_d + d_idx;
+    const float c = cos[cs_idx];
+    const float s = sin[cs_idx];
+    
+    device float2* ptr = is_q ? q : k;
+    float2 v = ptr[local_idx];
+    
+    float2 result;
+    result.x = v.x * c - v.y * s;
+    result.y = v.x * s + v.y * c;
+    
+    ptr[local_idx] = result;
+}
+
+// F16 interleaved - uses half2 for vectorized pair access, F32 compute for precision
+kernel void fused_rope_i_f16(
+    device half2* q [[buffer(0)]],
+    device half2* k [[buffer(1)]],
+    constant half* cos [[buffer(2)]],
+    constant half* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_num_pairs = q_bh * seq_len * half_d;
+    const uint k_num_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_num_pairs + k_num_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_num_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_num_pairs);
+    
+    const uint d_idx = local_idx % half_d;
+    const uint t_idx = (local_idx / half_d) % seq_len;
+    
+    const long pos = positions[t_idx];
+    const uint cs_idx = pos * half_d + d_idx;
+    
+    // F32 compute for precision (like CUDA)
+    const float c = float(cos[cs_idx]);
+    const float s = float(sin[cs_idx]);
+    
+    device half2* ptr = is_q ? q : k;
+    half2 v = ptr[local_idx];
+    
+    float vx = float(v.x);
+    float vy = float(v.y);
+    
+    half2 result;
+    result.x = half(vx * c - vy * s);
+    result.y = half(vx * s + vy * c);
+    
+    ptr[local_idx] = result;
+}
+
+// BF16 interleaved - uses Bfloat2_ for vectorized pair access, native BF16 compute
+kernel void fused_rope_i_bf16(
+    device Bfloat2_* q [[buffer(0)]],
+    device Bfloat2_* k [[buffer(1)]],
+    constant bfloat16_t* cos [[buffer(2)]],
+    constant bfloat16_t* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_num_pairs = q_bh * seq_len * half_d;
+    const uint k_num_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_num_pairs + k_num_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_num_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_num_pairs);
+    
+    const uint d_idx = local_idx % half_d;
+    const uint t_idx = (local_idx / half_d) % seq_len;
+    
+    const long pos = positions[t_idx];
+    const uint cs_idx = pos * half_d + d_idx;
+    
+    // Native BF16 compute (like CUDA's __hmul, __hsub, __hadd)
+    const bfloat16_t c = cos[cs_idx];
+    const bfloat16_t s = sin[cs_idx];
+    
+    device Bfloat2_* ptr = is_q ? q : k;
+    Bfloat2_ v = ptr[local_idx];
+    
+    Bfloat2_ result;
+    result.x = v.x * c - v.y * s;
+    result.y = v.x * s + v.y * c;
+    
+    ptr[local_idx] = result;
+}
+
+// ============================================================================
+// Non-Interleaved RoPE with Position Selection
+// Split pairs: x[i] and x[i + d/2]
+// ============================================================================
+
+// F32 non-interleaved
+kernel void fused_rope_f32(
+    device float* q [[buffer(0)]],
+    device float* k [[buffer(1)]],
+    constant float* cos [[buffer(2)]],
+    constant float* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_pairs = q_bh * seq_len * half_d;
+    const uint k_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_pairs + k_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_pairs);
+    
+    const uint pairs_per_bh = seq_len * half_d;
+    const uint i_bh = local_idx / pairs_per_bh;
+    const uint remainder = local_idx % pairs_per_bh;
+    const uint i_t = remainder / half_d;
+    const uint i_d = remainder % half_d;
+    
+    const long pos = positions[i_t];
+    const uint cs_idx = pos * half_d + i_d;
+    const float c = cos[cs_idx];
+    const float s = sin[cs_idx];
+    
+    const uint td = seq_len * d;
+    const uint i1 = i_bh * td + i_t * d + i_d;
+    const uint i2 = i1 + half_d;
+    
+    device float* ptr = is_q ? q : k;
+    float x1 = ptr[i1];
+    float x2 = ptr[i2];
+    
+    // Simple scalar ops
+    ptr[i1] = x1 * c - x2 * s;
+    ptr[i2] = x1 * s + x2 * c;
+}
+
+// F16 non-interleaved - F32 compute for precision
+kernel void fused_rope_f16(
+    device half* q [[buffer(0)]],
+    device half* k [[buffer(1)]],
+    constant half* cos [[buffer(2)]],
+    constant half* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_pairs = q_bh * seq_len * half_d;
+    const uint k_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_pairs + k_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_pairs);
+    
+    const uint pairs_per_bh = seq_len * half_d;
+    const uint i_bh = local_idx / pairs_per_bh;
+    const uint remainder = local_idx % pairs_per_bh;
+    const uint i_t = remainder / half_d;
+    const uint i_d = remainder % half_d;
+    
+    const long pos = positions[i_t];
+    const uint cs_idx = pos * half_d + i_d;
+    
+    // F32 compute for precision
+    const float c = float(cos[cs_idx]);
+    const float s = float(sin[cs_idx]);
+    
+    const uint td = seq_len * d;
+    const uint i1 = i_bh * td + i_t * d + i_d;
+    const uint i2 = i1 + half_d;
+    
+    device half* ptr = is_q ? q : k;
+    float x1 = float(ptr[i1]);
+    float x2 = float(ptr[i2]);
+    
+    // Simple scalar ops with F32 precision
+    ptr[i1] = half(x1 * c - x2 * s);
+    ptr[i2] = half(x1 * s + x2 * c);
+}
+
+// BF16 non-interleaved - native BF16 compute
+kernel void fused_rope_bf16(
+    device bfloat16_t* q [[buffer(0)]],
+    device bfloat16_t* k [[buffer(1)]],
+    constant bfloat16_t* cos [[buffer(2)]],
+    constant bfloat16_t* sin [[buffer(3)]],
+    constant long* positions [[buffer(4)]],
+    constant uint& q_bh [[buffer(5)]],
+    constant uint& k_bh [[buffer(6)]],
+    constant uint& seq_len [[buffer(7)]],
+    constant uint& d [[buffer(8)]],
+    uint idx [[thread_position_in_grid]]
+) {
+    const uint half_d = d / 2;
+    const uint q_pairs = q_bh * seq_len * half_d;
+    const uint k_pairs = k_bh * seq_len * half_d;
+    const uint total_pairs = q_pairs + k_pairs;
+    
+    if (idx >= total_pairs) return;
+    
+    const bool is_q = (idx < q_pairs);
+    const uint local_idx = is_q ? idx : (idx - q_pairs);
+    
+    const uint pairs_per_bh = seq_len * half_d;
+    const uint i_bh = local_idx / pairs_per_bh;
+    const uint remainder = local_idx % pairs_per_bh;
+    const uint i_t = remainder / half_d;
+    const uint i_d = remainder % half_d;
+    
+    const long pos = positions[i_t];
+    const uint cs_idx = pos * half_d + i_d;
+    
+    // Native BF16 compute
+    const bfloat16_t c = cos[cs_idx];
+    const bfloat16_t s = sin[cs_idx];
+    
+    const uint td = seq_len * d;
+    const uint i1 = i_bh * td + i_t * d + i_d;
+    const uint i2 = i1 + half_d;
+    
+    device bfloat16_t* ptr = is_q ? q : k;
+    bfloat16_t x1 = ptr[i1];
+    bfloat16_t x2 = ptr[i2];
+    
+    // Simple scalar ops with native BF16
+    ptr[i1] = x1 * c - x2 * s;
+    ptr[i2] = x1 * s + x2 * c;
+}


### PR DESCRIPTION
## Summary

This PR adds a **Fused Rotary Position Embedding (RoPE)** kernel that combines the `index_select` and RoPE operations into a single kernel launch, reducing overhead and improving performance.

## Key Features

- **Fused kernel**: Combines position-based cos/sin selection with RoPE application (2 kernels → 1)
- **GQA Support**: Handles different head counts for Q and K tensors
- **Multi-backend**: Full support for both CUDA and Metal
- **Data types**: Supports F32, F16, and BF16
- **Layouts**: Supports both interleaved and non-interleaved RoPE layouts

## CUDA Optimizations

- Grid-stride loops for all tensor sizes
- Native BF16 compute using `__hmul`, `__hadd`, `__hsub`
- F16 uses F32 precision for accuracy
- Vectorized `float2`/`__half2`/`__nv_bfloat162` for interleaved access
- `__launch_bounds__` for register optimization

## Metal Optimizations

- Native BF16 compute (matches CUDA approach)
- F16 uses F32 precision for accuracy
- Vectorized `float2`/`half2`/`Bfloat2_` for interleaved access
- Single kernel for Q+K processing

## Files Changed

- `src/kernels/src/fused_rope.cu` - CUDA kernel implementation
- `src/kernels/src/ffi.rs` - FFI bindings for CUDA
- `src/metal-kernels/src/fused_rope.metal` - Metal kernel implementation
- `src/metal-kernels/src/lib.rs` - Metal host code
- `src/metal-kernels/build.rs` - Build configuration
- `src/fused_rope.rs` - Unified Rust API
- `src/lib.rs` - Module exports

## Usage

```rust
use attention_rs::fused_rope::FusedRope;

// In-place version (modifies Q and K directly)
FusedRope::apply_inplace(&q, &k, &cos, &sin, &positions, is_interleaved)?;

// Copy version (returns new tensors)
let (q_out, k_out) = FusedRope::apply(&q, &k, &cos, &sin, &positions, is_interleaved)?;
```
