### PR TITLE
Use light expert offset calculation on pre-sm80 builds

### DIFF
--- a/src/kernels/src/moe_wmma_gguf.cu
+++ b/src/kernels/src/moe_wmma_gguf.cu
@@ -401,7 +401,11 @@ extern "C" void moe_gemm_gguf_prefill(
 
     int32_t* expert_offsets;
     cudaMallocAsync(&expert_offsets, (num_experts + 1) * sizeof(int32_t), stream);
+    #ifdef NO_BF16_KERNEL
+    calculate_expert_offsets_light(expert_ids, size_m, expert_counts, expert_offsets, num_experts, stream);
+    #else
     calculate_expert_offsets(expert_ids, size_m, expert_counts, expert_offsets, num_experts, stream);
+    #endif
     
     int grid_n = CEILDIV(size_n, N_BLK);
     dim3 grid(num_experts, grid_n, 1);


### PR DESCRIPTION
### Motivation
- V100 and other pre-sm80 GPUs have limited `thrust` support, so when the `NO_BF16_KERNEL` build path is used (indicating pre-sm80) we should avoid the thrust-based routine and use the lightweight offset calculator instead.

### Description
- In `moe_gemm_gguf_prefill` (file `src/kernels/src/moe_wmma_gguf.cu`) call `calculate_expert_offsets_light` when `NO_BF16_KERNEL` is defined and otherwise call `calculate_expert_offsets`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757f451578832eb64c2a04f44679c8)