### PR TITLE
Allow decalring FI source and commit hash in env

### DIFF
--- a/src/kernels/build.rs
+++ b/src/kernels/build.rs
@@ -86,10 +86,16 @@ fn main() -> Result<()> {
         println!("cargo:rerun-if-changed=src/flashinfer_adapter.cu");
         // DO not change this, this featch custom flashinfer v0.6.2 headers
         // which is compatible with our code (added more gqa group_size)
+        let fi_repo = std::env::var("CARGO_FEATURE_FLASHINFER_REPO").unwrap_or(
+            "https://github.com/guoqingbao/flashinfer.git".to_string()
+        );
+        let fi_commit = std::env::var("CARGO_FEATURE_FLASHINFER_COMMIT").unwrap_or(
+            "960cb902ce15ec085d42aa1bbe7026979c9a04dd".to_string() // v0.6.2
+        );
         builder = builder.arg("-DUSE_FLASHINFER").with_git_dependency(
             "flashinfer",
-            "https://github.com/guoqingbao/flashinfer.git",
-            "960cb902ce15ec085d42aa1bbe7026979c9a04dd", // v0.6.2
+            fi_repo.as_str(),
+            fi_commit.as_str(),
             vec!["include"],
             false,
         );


### PR DESCRIPTION
Hardcoded repository and commit sources make testing require an additional step out-of-tree wherein the library must be updated and consumers pointed to the updated branch in order to test FI changes.

Allow use of env vars to override the defaults with safe fallback to the prior settings - CARGO_FEATURE_FLASHINFER_REPO for repo URL and CARGO_FEATURE_FLASHINFER_COMMIT for commit hash.