### PR TITLE
rope_scale/rope_theta Propagation for MLA Prefill

### DIFF
--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -2714,6 +2714,8 @@ extern "C" {
         num_heads: c_int,
         page_size: c_int,
         sm_scale: f32,
+        rope_scale: f32,
+        rope_theta: f32,
         float_workspace: *mut c_void,
         float_workspace_size: i64,
         int_workspace: *mut c_void,

--- a/src/kernels/src/flashinfer_mla.cu
+++ b/src/kernels/src/flashinfer_mla.cu
@@ -197,6 +197,7 @@ void mla_prefill_run_typed(
     void* ckv_cache, void* kpe_cache,
     const int32_t* kv_indices,
     int32_t num_heads, int32_t page_size, float sm_scale,
+    float rope_scale, float rope_theta,
     void* float_workspace, size_t float_workspace_size,
     void* int_workspace, size_t int_workspace_size,
     const int64_t* plan_info_vec, bool causal, cudaStream_t stream)
@@ -262,6 +263,8 @@ void mla_prefill_run_typed(
     params.o_stride_h = HEAD_DIM_CKV;
 
     params.sm_scale = sm_scale;
+    params.rope_scale = rope_scale;
+    params.rope_theta = rope_theta;
     params.return_lse_base_on_e = false;
 
     cudaError_t status;
@@ -409,6 +412,7 @@ void flashinfer_mla_prefill_run_wrapper(
     void* ckv_cache, void* kpe_cache,
     const int32_t* kv_indices,
     int32_t num_heads, int32_t page_size, float sm_scale,
+    float rope_scale, float rope_theta,
     void* float_workspace, int64_t float_workspace_size,
     void* int_workspace, int64_t int_workspace_size,
     const int64_t* plan_info,
@@ -423,14 +427,14 @@ void flashinfer_mla_prefill_run_wrapper(
     if (dtype == 1) {
         mla_prefill_run_typed<nv_bfloat16>(
             o, q_nope, q_pe, ckv_cache, kpe_cache, kv_indices,
-            num_heads, page_size, sm_scale,
+            num_heads, page_size, sm_scale, rope_scale, rope_theta,
             float_workspace, float_workspace_size,
             int_workspace, int_workspace_size,
             plan_info, causal, stream);
     } else {
         mla_prefill_run_typed<half>(
             o, q_nope, q_pe, ckv_cache, kpe_cache, kv_indices,
-            num_heads, page_size, sm_scale,
+            num_heads, page_size, sm_scale, rope_scale, rope_theta,
             float_workspace, float_workspace_size,
             int_workspace, int_workspace_size,
             plan_info, causal, stream);

--- a/src/mla.rs
+++ b/src/mla.rs
@@ -546,6 +546,8 @@ pub fn mla_prefill_run(
     num_heads: usize,
     page_size: usize,
     sm_scale: f32,
+    rope_scale: f32,
+    rope_theta: f32,
     plan_info: &[i64],
     causal: bool,
 ) -> Result<Tensor> {
@@ -583,6 +585,8 @@ pub fn mla_prefill_run(
             num_heads as i32,
             page_size as i32,
             sm_scale,
+            rope_scale,
+            rope_theta,
             ws_float_ptr,
             WORKSPACE_FLOAT_SIZE as i64,
             ws_int_ptr,


### PR DESCRIPTION
Ensure that YARN-scaled MLA models correctly apply RoPE position scaling during prefill attention computation.

For YARN-scaled models (e.g., 12X context extension), the MLA prefill path was not propagating rope_scale and rope_theta parameters from the vllm.rs MlaAttention layer through to the FlashInfer CUDA kernel.

This caused positions beyond the original training context to be computed with incorrect RoPE frequencies, resulting in attention weights that were out of training distribution.

The fix ensures rope_scale = 1.0/factor is computed in MlaAttention::new() and propagated through the entire call chain:

1. vllm.rs/src/models/layers/mla_attention.rs:222
   - rope_scale = 1.0 / factor (was hardcoded to 1.0)

2. attention.rs/src/mla.rs:540-601
   - mla_prefill_run() now accepts rope_scale and rope_theta parameters

3. attention.rs/src/kernels/src/ffi.rs:2707-2727
   - flashinfer_mla_prefill_run_wrapper() FFI accepts rope_scale/rope_theta

4. attention.rs/src/kernels/src/flashinfer_mla.cu:194-443
   - mla_prefill_run_typed() sets params.rope_scale and params.rope_theta
   - flashinfer_mla_prefill_run_wrapper() passes parameters to typed function

5. vllm.rs/src/models/layers/mla_attention.rs:361-374
   - forward() passes self.rope_scale and self.rope_theta to mla_prefill_run

For 12X YARN-scaled models:
- rope_scale = 1.0/12.0 = 0.0833 (was 1.0)
- Position 12000 is now scaled to 1000 before RoPE computation
- Attention weights are computed within training distribution