### PR TITLE
Clamp GDN decay to prevent exp() over/underflow

### DIFF
--- a/src/kernels/src/gdn.cu
+++ b/src/kernels/src/gdn.cu
@@ -669,7 +669,9 @@ __global__ void gated_delta_rule_decode_slots_gqa_kernel(
     float* scalars = smem + 2 * BK;
 
     if (tid == 0) {
-        scalars[0] = expf(to_float(g[b * num_v_heads + v_head_idx]));
+        float decay_val = to_float(g[b * num_v_heads + v_head_idx]);
+        decay_val = fmaxf(fminf(decay_val, 100.0f), -100.0f);
+        scalars[0] = expf(decay_val);
         scalars[1] = to_float(beta[b * num_v_heads + v_head_idx]);
     }
 
@@ -1882,7 +1884,9 @@ __global__ void gated_delta_rule_recurrence_varlen_gqa_kernel(
             }
         }
         if (tid == 0) {
-            scalars[0][0] = expf(to_float(g_base[0]));
+            float decay_val = to_float(g_base[0]);
+            decay_val = fmaxf(fminf(decay_val, 100.0f), -100.0f);
+            scalars[0][0] = expf(decay_val);
             scalars[0][1] = to_float(beta_base[0]);
         }
         __syncthreads();
@@ -1905,7 +1909,9 @@ __global__ void gated_delta_rule_recurrence_varlen_gqa_kernel(
                 }
             }
             if (tid == 0) {
-                scalars[nxt][0] = expf(to_float(g_base[(t + 1) * token_stride_g]));
+                float decay_val = to_float(g_base[(t + 1) * token_stride_g]);
+                decay_val = fmaxf(fminf(decay_val, 100.0f), -100.0f);
+                scalars[nxt][0] = expf(decay_val);
                 scalars[nxt][1] = to_float(beta_base[(t + 1) * token_stride_g]);
             }
         }


### PR DESCRIPTION
The gated delta rule recurrence and decode kernels compute `decay = exp(g)` where g is the log-space decay parameter. For large context lengths , the accumulated decay values can exceed FP32 safe range, causing:
 - exp(-709) ≈ 0 (underflow to zero) - causes complete forgetting
 - exp(709) ≈ inf (overflow) - causes numerical instability

The fix clamps decay values to [-100, 100] before calling expf():
```
float decay_val = to_float(g[...]);
decay_val = fmaxf(fminf(decay_val, 100.0f), -100.0f);
scalars[0] = expf(decay_val);
```

Mathematical justification:

exp(-100) ≈ 3.7e-44 (still non-zero)
exp(100) ≈ 2.7e43 (finite)

The clamping range [-100, 100] is viable for all practical decay values to include yarn-scaled long-context inference.