### PR TITLE
Allow Mask Processing in DFlash-v2 and Sampling Kernel

### DIFF
--- a/custom-mask
+++ b/custom-mask
@@ -1,0 +1,111 @@
+diff --git i/src/flashinfer.rs w/src/flashinfer.rs
+index f62990a..6d5fb28 100644
+--- i/src/flashinfer.rs
++++ w/src/flashinfer.rs
+@@ -963,6 +963,7 @@ pub fn prefill_with_plan(
+     logits_soft_cap: Option<f32>,
+     plan_info: &[i64],
+     enable_cuda_graph: bool,
++    custom_mask: Option<&Tensor>,
+ ) -> Result<Tensor> {
+     let op = FlashInferPrefillWithPlan {
+         key_cache: key_cache.clone(),
+@@ -983,6 +984,7 @@ pub fn prefill_with_plan(
+         logits_soft_cap: logits_soft_cap.unwrap_or(0.0f32),
+         plan_info: plan_info.to_vec(),
+         enable_cuda_graph,
++        custom_mask: custom_mask.cloned(),
+     };
+     q.apply_op1(op)
+ }
+@@ -1006,6 +1008,7 @@ struct FlashInferPrefillWithPlan {
+     pub logits_soft_cap: f32,
+     pub plan_info: Vec<i64>,
+     pub enable_cuda_graph: bool,
++    pub custom_mask: Option<Tensor>,
+ }
+ 
+ impl candle::CustomOp1 for FlashInferPrefillWithPlan {
+@@ -1097,6 +1100,24 @@ impl FlashInferPrefillWithPlan {
+             (std::ptr::null(), std::ptr::null())
+         };
+ 
++        // topk>1 tree verify: the custom ancestor mask ([q_len, kv_len] F32 bias, 0 = attend,
++        // -inf = masked), passed to the flashinfer kernel (sglang's custom_mask_buf mechanism).
++        let (custom_mask_ptr, custom_mask_q_len, custom_mask_kv_len) = match &self.custom_mask {
++            Some(cm) => {
++                let (cm_s, cm_l) = cm.storage_and_layout();
++                let ptr = match &*cm_s {
++                    Storage::Cuda(c) => c
++                        .as_cuda_slice::<f32>()?
++                        .slice(cm_l.start_offset()..)
++                        .device_ptr(),
++                    _ => std::ptr::null(),
++                };
++                let (q_len, kv_len) = cm.dims2()?;
++                (*ptr as *const std::ffi::c_void, q_len as i32, kv_len as i32)
++            }
++            None => (std::ptr::null(), 0, 0),
++        };
++
+         unsafe {
+             kernels::ffi::flashinfer_prefill_run_wrapper(
+                 out_ptr,
+@@ -1125,6 +1146,9 @@ impl FlashInferPrefillWithPlan {
+                 data_type,
+                 out_data_type,
+                 self.plan_info.as_ptr(),
++                custom_mask_ptr,
++                custom_mask_q_len,
++                custom_mask_kv_len,
+                 *dev.cu_stream() as i64,
+             );
+         }
+diff --git i/src/kernels/src/ffi.rs w/src/kernels/src/ffi.rs
+index 4f1ee2b..ff1be72 100644
+--- i/src/kernels/src/ffi.rs
++++ w/src/kernels/src/ffi.rs
+@@ -1613,6 +1613,9 @@ extern "C" {
+         data_type: i32,
+         out_data_type: i32,
+         plan_info_vec: *const i64,
++        custom_mask_ptr: *const c_void,
++        custom_mask_q_len: i32,
++        custom_mask_kv_len: i32,
+         stream: i64,
+     );
+ 
+diff --git i/src/lib.rs w/src/lib.rs
+index b208a91..0a05964 100644
+--- i/src/lib.rs
++++ w/src/lib.rs
+@@ -279,6 +279,11 @@ pub struct InputMetadata {
+     pub seqlens: Option<Vec<u32>>,
+     pub flashinfer_metadata: Option<FlashInferMetadata>,
+     pub is_mtp_verify: bool,
++    /// Optional custom attention mask `[q_len, kv_len]` (bool, true = attend) applied on top of
++    /// the standard causal/sliding mask. Used by topk>1 tree verification (each tree node attends
++    /// only to its ancestors + itself). `None` = no custom mask.
++    #[cfg_attr(feature = "cuda", allow(unused))]
++    pub custom_attn_mask: Option<Tensor>,
+ }
+ 
+ #[allow(dead_code)]
+@@ -574,6 +579,17 @@ impl PagedAttention {
+                     att = att.broadcast_add(&q_chunk_mask)?;
+                 }
+ 
++                // topk>1 tree verify: apply the custom ancestor mask (each tree node attends to
++                // its ancestors + itself). `custom_attn_mask` is [q_len, kv_len] (0 = attend,
++                // -inf = masked); narrow to this query chunk and broadcast over heads.
++                if let Some(custom_mask) = &input_metadata.custom_attn_mask {
++                    let cm = custom_mask
++                        .narrow(0, offset, len)?
++                        .unsqueeze(0)?
++                        .unsqueeze(0)?;
++                    att = att.broadcast_add(&cm)?;
++                }
++
+                 att = candle_nn::ops::softmax_last_dim(&att.to_dtype(candle_core::DType::F32)?)?
+                     .to_dtype(att.dtype())?;
+ 

--- a/src/kernels/src/fast_topk.cu
+++ b/src/kernels/src/fast_topk.cu
@@ -289,10 +289,12 @@ __global__ void dflash_select_candidates_kernel(
     const float* __restrict__ predecessor_codebook,
     const float* __restrict__ successor_codebook,
     const uint32_t* __restrict__ anchor_token,
+    const float* __restrict__ allow,
     uint32_t* __restrict__ selected_tokens,
     const int sequence_len,
     const int rank,
-    const int topk) {
+    const int topk,
+    const int vocab_size) {
 
     // DFlash2 checkpoints use topk=16 and rank=256. Mapping one group of
     // threads to each candidate keeps the whole K-way edge score in one
@@ -335,6 +337,13 @@ __global__ void dflash_select_candidates_kernel(
                     edge += partial_dots[candidate * blockDim.x + lane];
                 const float score =
                     unary_logits[position * topk + candidate] + edge;
+                // Grammar gate: a candidate disallowed at this position by the
+                // per-position VOB allow matrix ([sequence_len, vocab_size],
+                // 1.0 = legal) is scored -inf so the walk never selects it.
+                if (allow != nullptr &&
+                    allow[(int64_t)position * vocab_size +
+                         candidate_ids[position * topk + candidate]] == 0.0f)
+                    continue;
                 if (score > best_score) {
                     best_score = score;
                     best_candidate = candidate;
@@ -349,17 +358,19 @@ __global__ void dflash_select_candidates_kernel(
     }
 }
 
-cudaError_t dflash_select_candidates(
+cudaError_t dflash_select_candidates_masked(
     const float* hidden,                // [sequence_len, rank]
     const float* unary_logits,          // [sequence_len, topk]
     const uint32_t* candidate_ids,      // [sequence_len, topk]
     const float* predecessor_codebook,  // [vocab_size, rank]
     const float* successor_codebook,    // [vocab_size, rank]
     const uint32_t* anchor_token,
-    uint32_t* selected_tokens,          // [sequence_len]
+    const float* allow,                // [sequence_len, vocab_size] or nullptr
+    uint32_t* selected_tokens,         // [sequence_len]
     int sequence_len,
     int rank,
     int topk,
+    int vocab_size,
     int64_t stream_) {
 
     if (hidden == nullptr || unary_logits == nullptr || candidate_ids == nullptr ||
@@ -367,6 +378,8 @@ cudaError_t dflash_select_candidates(
         anchor_token == nullptr || selected_tokens == nullptr ||
         sequence_len <= 0 || rank <= 0 || topk <= 0 || topk > 32 ||
         topk > 256)
+        return cudaErrorInvalidValue;
+    if (allow != nullptr && vocab_size <= 0)
         return cudaErrorInvalidValue;
 
     const int lanes_per_candidate = 256 / topk;
@@ -382,11 +395,31 @@ cudaError_t dflash_select_candidates(
         predecessor_codebook,
         successor_codebook,
         anchor_token,
+        allow,
         selected_tokens,
         sequence_len,
         rank,
-        topk);
+        topk,
+        vocab_size);
     return cudaGetLastError();
+}
+
+cudaError_t dflash_select_candidates(
+    const float* hidden,
+    const float* unary_logits,
+    const uint32_t* candidate_ids,
+    const float* predecessor_codebook,
+    const float* successor_codebook,
+    const uint32_t* anchor_token,
+    uint32_t* selected_tokens,
+    int sequence_len,
+    int rank,
+    int topk,
+    int64_t stream_) {
+    return dflash_select_candidates_masked(
+        hidden, unary_logits, candidate_ids, predecessor_codebook,
+        successor_codebook, anchor_token, nullptr, selected_tokens,
+        sequence_len, rank, topk, 0, stream_);
 }
 
 }  // extern "C"

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -843,6 +843,51 @@ extern "C" {
         stream: i64,
     );
 
+    // Masked sampling: `mask_d` is a [B,V] F32 grammar allow-matrix (1.0 = legal,
+    // 0.0 = illegal) applied in the top-k stage so disallowed tokens are never
+    // sampled. Pass null() for unmasked sampling (identical to the plain entries).
+    pub fn sampling_masked_f32(
+        logits_d: *const f32,
+        mask_d: *const f32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
+    pub fn sampling_masked_f16(
+        logits_d: *const c_void,
+        mask_d: *const f32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
+    pub fn sampling_masked_bf16(
+        logits_d: *const c_void,
+        mask_d: *const f32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
     // Fused Rotary Position Embedding (RoPE) kernels - with position selection
     // Non-interleaved versions - support GQA, fuses index_select
     pub fn fused_rope_f32(

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -4574,6 +4574,22 @@ extern "C" {
         stream: i64,
     ) -> c_int;
 
+    pub fn dflash_select_candidates_masked(
+        hidden: *const c_void,
+        unary_logits: *const f32,
+        candidate_ids: *const u32,
+        predecessor_codebook: *const f32,
+        successor_codebook: *const f32,
+        anchor_token: *const u32,
+        allow: *const f32,
+        selected_tokens: *mut u32,
+        sequence_len: c_int,
+        rank: c_int,
+        topk: c_int,
+        vocab_size: c_int,
+        stream: i64,
+    ) -> c_int;
+
     pub fn dflash_grouped_conv_bf16(
         hidden: *const c_void,
         delta: *const c_void,

--- a/src/kernels/src/ffi.rs
+++ b/src/kernels/src/ffi.rs
@@ -888,6 +888,50 @@ extern "C" {
         stream: i64,
     );
 
+    // VOB (Valid Output Boundary) sampling: `vob_d` is a [B, V/32] U32 bitset
+    // (bit i set = token allowed). 8x less data than the F32 mask path.
+    pub fn sampling_vob_f32(
+        logits_d: *const f32,
+        vob_d: *const u32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
+    pub fn sampling_vob_f16(
+        logits_d: *const c_void,
+        vob_d: *const u32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
+    pub fn sampling_vob_bf16(
+        logits_d: *const c_void,
+        vob_d: *const u32,
+        out_tokens_d: *mut i32,
+        B: i32,
+        V: i32,
+        K: i32,
+        temperature: f32,
+        top_p: f32,
+        seed: u64,
+        token_pos: u64,
+        stream: i64,
+    );
+
     // Fused Rotary Position Embedding (RoPE) kernels - with position selection
     // Non-interleaved versions - support GQA, fuses index_select
     pub fn fused_rope_f32(

--- a/src/kernels/src/gpu_sampling.cu
+++ b/src/kernels/src/gpu_sampling.cu
@@ -591,3 +591,50 @@ extern "C" void sampling_masked_bf16(
     }
   #endif
 }
+
+// ---------------------------------------------------------------------------
+// VOB (Valid Output Boundary) sampling: [B, V/32] U32 bitset instead of [B,V] F32.
+// 8x less data to transfer. The kernel does a bitwise AND instead of float compare.
+// TODO: implement stageA_local_topk_vob with uint32_t* vob_d for the bitwise path.
+// For now, delegate to the masked path (correct but not yet optimized).
+// ---------------------------------------------------------------------------
+
+extern "C" void sampling_vob_f32(
+    const float* logits_d,
+    const uint32_t* vob_d,
+    int* out_tokens_d,
+    int B, int V, int K,
+    float temperature, float top_p,
+    uint64_t seed, uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    // TODO: fused VOB kernel (bitwise AND in stageA). For now, unmasked.
+    (void)vob_d;
+    sampling_masked_f32(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+}
+
+extern "C" void sampling_vob_f16(
+    const void* logits_d,
+    const uint32_t* vob_d,
+    int* out_tokens_d,
+    int B, int V, int K,
+    float temperature, float top_p,
+    uint64_t seed, uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    (void)vob_d;
+    sampling_masked_f16(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+}
+
+extern "C" void sampling_vob_bf16(
+    const void* logits_d,
+    const uint32_t* vob_d,
+    int* out_tokens_d,
+    int B, int V, int K,
+    float temperature, float top_p,
+    uint64_t seed, uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    (void)vob_d;
+    sampling_masked_bf16(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+}

--- a/src/kernels/src/gpu_sampling.cu
+++ b/src/kernels/src/gpu_sampling.cu
@@ -166,6 +166,66 @@ __global__ void stageA_local_topk(
   }
 }
 
+// VOB variant: [B, V/32] U32 bitset instead of [B,V] F32 mask.
+// Bit i set = token allowed. 8x less data, bitwise AND instead of float compare.
+template<int K, int BLOCK_THREADS, int ITEMS_PER_THREAD, typename T>
+__global__ void stageA_local_topk_vob(
+    const T* __restrict__ logits, // [B,V]
+    const uint32_t* __restrict__ vob, // [B, V/32] bitset, or nullptr
+    int B, int V,
+    float temperature,
+    int tiles_per_row,
+    float* __restrict__ out_vals,
+    int* __restrict__ out_idx
+) {
+  int b = blockIdx.x;
+  int tile = blockIdx.y;
+  if (b >= B) return;
+
+  constexpr int CHUNK = BLOCK_THREADS * ITEMS_PER_THREAD;
+  int base = tile * CHUNK;
+
+  const T* row = logits + (size_t)b * (size_t)V;
+  const uint32_t* vobrow = vob ? (vob + (size_t)b * ((V + 31) / 32)) : nullptr;
+
+  float invT = (temperature > 1e-6f) ? (1.0f / temperature) : 1e6f;
+
+  float v[ITEMS_PER_THREAD];
+  int   i[ITEMS_PER_THREAD];
+
+  #pragma unroll
+  for (int it = 0; it < ITEMS_PER_THREAD; ++it) {
+    int idx = base + threadIdx.x + it * BLOCK_THREADS;
+    if (idx < V) {
+      float scaled = to_float(row[idx]) * invT;
+      // VOB gate: bit not set = disallowed -> -inf
+      if (vobrow != nullptr && ((vobrow[idx >> 5] >> (idx & 31)) & 1u) == 0u)
+        scaled = -CUDART_INF_F;
+      v[it] = scaled;
+      i[it] = idx;
+    } else {
+      v[it] = -CUDART_INF_F;
+      i[it] = -1;
+    }
+  }
+
+  using BlockSort = cub::BlockRadixSort<float, BLOCK_THREADS, ITEMS_PER_THREAD, int>;
+  __shared__ typename BlockSort::TempStorage temp;
+  BlockSort(temp).SortDescending(v, i);
+  __syncthreads();
+
+  int out_base = (b * tiles_per_row + tile) * K;
+
+  #pragma unroll
+  for (int it = 0; it < ITEMS_PER_THREAD; ++it) {
+    int rank = threadIdx.x + it * BLOCK_THREADS;
+    if (rank < K) {
+      out_vals[out_base + rank] = v[it];
+      out_idx[out_base + rank]  = i[it];
+    }
+  }
+}
+
 // ---------------- Stage B: reduce tiles -> global topK -> softmax -> top-p -> sample ----------------
 //
 // One block per batch element.
@@ -350,6 +410,64 @@ template void gpu_topk_topp_sample<32, __nv_bfloat16>(const __nv_bfloat16*, cons
 template void gpu_topk_topp_sample<64, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
 template void gpu_topk_topp_sample<128, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
 template void gpu_topk_topp_sample<256, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
+#endif
+
+// ---------------------------------------------------------------------------
+// VOB variant: uses [B, V/32] U32 bitset instead of [B,V] F32 mask.
+// 8x less data, bitwise AND instead of float compare in stageA.
+// ---------------------------------------------------------------------------
+template<int K, typename T>
+void gpu_topk_topp_sample_vob(
+    const T* logits_d,
+    const uint32_t* vob_d,  // [B, V/32] bitset, or nullptr
+    int* out_tokens_d,
+    const SamplerParams& p,
+    cudaStream_t stream
+) {
+  constexpr int BLOCK_THREADS = 256;
+  constexpr int ITEMS_PER_THREAD = 4;
+  constexpr int CHUNK = BLOCK_THREADS * ITEMS_PER_THREAD;
+
+  int tiles = (p.V + CHUNK - 1) / CHUNK;
+
+  float* tile_vals_d = nullptr;
+  int*   tile_idx_d  = nullptr;
+  size_t vals_bytes = (size_t)p.B * (size_t)tiles * (size_t)K * sizeof(float);
+  size_t idx_bytes  = (size_t)p.B * (size_t)tiles * (size_t)K * sizeof(int);
+  CUDA_CHECK(cudaMallocAsync(&tile_vals_d, vals_bytes, stream));
+  CUDA_CHECK(cudaMallocAsync(&tile_idx_d,  idx_bytes,  stream));
+
+  dim3 gridA(p.B, tiles, 1);
+  dim3 blockA(BLOCK_THREADS, 1, 1);
+  stageA_local_topk_vob<K, BLOCK_THREADS, ITEMS_PER_THREAD, T>
+      <<<gridA, blockA, 0, stream>>>(
+          logits_d, vob_d, p.B, p.V, p.temperature, tiles, tile_vals_d, tile_idx_d);
+
+  dim3 gridB(p.B, 1, 1);
+  dim3 blockB(256, 1, 1);
+  stageB_reduce_and_sample<K, 256>
+      <<<gridB, blockB, 0, stream>>>(
+          p.B, tiles, tile_vals_d, tile_idx_d, p.top_p, p.top_k, p.seed, p.token_pos, out_tokens_d);
+
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaFreeAsync(tile_vals_d, stream));
+  CUDA_CHECK(cudaFreeAsync(tile_idx_d,  stream));
+}
+
+// Explicit VOB instantiations
+template void gpu_topk_topp_sample_vob<32, float>(const float*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<64, float>(const float*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<128, float>(const float*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<256, float>(const float*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<32, __half>(const __half*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<64, __half>(const __half*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<128, __half>(const __half*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<256, __half>(const __half*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+#ifndef NO_BF16_KERNEL
+template void gpu_topk_topp_sample_vob<32, __nv_bfloat16>(const __nv_bfloat16*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<64, __nv_bfloat16>(const __nv_bfloat16*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<128, __nv_bfloat16>(const __nv_bfloat16*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample_vob<256, __nv_bfloat16>(const __nv_bfloat16*, const uint32_t*, int*, const SamplerParams&, cudaStream_t);
 #endif
 
 
@@ -608,9 +726,28 @@ extern "C" void sampling_vob_f32(
     uint64_t seed, uint64_t token_pos,
     int64_t stream_ptr)
 {
-    // TODO: fused VOB kernel (bitwise AND in stageA). For now, unmasked.
-    (void)vob_d;
-    sampling_masked_f32(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+    SamplerParams p;
+    p.B = B; p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample_vob<32, float>(logits_d, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample_vob<64, float>(logits_d, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample_vob<128, float>(logits_d, vob_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample_vob<256, float>(logits_d, vob_d, out_tokens_d, p, stream);
+    }
 }
 
 extern "C" void sampling_vob_f16(
@@ -622,8 +759,29 @@ extern "C" void sampling_vob_f16(
     uint64_t seed, uint64_t token_pos,
     int64_t stream_ptr)
 {
-    (void)vob_d;
-    sampling_masked_f16(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+    SamplerParams p;
+    p.B = B; p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    const __half* logits = reinterpret_cast<const __half*>(logits_d);
+
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample_vob<32, __half>(logits, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample_vob<64, __half>(logits, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample_vob<128, __half>(logits, vob_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample_vob<256, __half>(logits, vob_d, out_tokens_d, p, stream);
+    }
 }
 
 extern "C" void sampling_vob_bf16(
@@ -635,6 +793,28 @@ extern "C" void sampling_vob_bf16(
     uint64_t seed, uint64_t token_pos,
     int64_t stream_ptr)
 {
-    (void)vob_d;
-    sampling_masked_bf16(logits_d, nullptr, out_tokens_d, B, V, K, temperature, top_p, seed, token_pos, stream_ptr);
+    SamplerParams p;
+    p.B = B; p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+#ifndef NO_BF16_KERNEL
+    const __nv_bfloat16* logits = reinterpret_cast<const __nv_bfloat16*>(logits_d);
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample_vob<32, __nv_bfloat16>(logits, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample_vob<64, __nv_bfloat16>(logits, vob_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample_vob<128, __nv_bfloat16>(logits, vob_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample_vob<256, __nv_bfloat16>(logits, vob_d, out_tokens_d, p, stream);
+    }
+#endif
 }

--- a/src/kernels/src/gpu_sampling.cu
+++ b/src/kernels/src/gpu_sampling.cu
@@ -108,6 +108,7 @@ static __device__ __forceinline__ void merge_topk_desc_safe(
 template<int K, int BLOCK_THREADS, int ITEMS_PER_THREAD, typename T>
 __global__ void stageA_local_topk(
     const T* __restrict__ logits, // [B,V]
+    const float* __restrict__ mask, // [B,V] 1.0=legal / 0.0=illegal, or nullptr
     int B, int V,
     float temperature,
     int tiles_per_row,                // number of tiles along vocab
@@ -122,6 +123,7 @@ __global__ void stageA_local_topk(
   int base = tile * CHUNK;
 
   const T* row = logits + (size_t)b * (size_t)V;
+  const float* mrow = mask ? (mask + (size_t)b * (size_t)V) : nullptr;
 
   float invT = (temperature > 1e-6f) ? (1.0f / temperature) : 1e6f;
 
@@ -132,7 +134,12 @@ __global__ void stageA_local_topk(
   for (int it = 0; it < ITEMS_PER_THREAD; ++it) {
     int idx = base + threadIdx.x + it * BLOCK_THREADS;
     if (idx < V) {
-      v[it] = to_float(row[idx]) * invT;
+      float scaled = to_float(row[idx]) * invT;
+      // Grammar gate: a disallowed vocab entry is dropped from the top-k (and thus
+      // from sampling) by forcing its score to -inf.
+      if (mrow != nullptr && mrow[idx] == 0.0f)
+        scaled = -CUDART_INF_F;
+      v[it] = scaled;
       i[it] = idx;
     } else {
       v[it] = -CUDART_INF_F;
@@ -278,6 +285,7 @@ __global__ void stageB_reduce_and_sample(
 template<int K, typename T>
 void gpu_topk_topp_sample(
     const T* logits_d,
+    const float* mask_d,   // [B,V] 1.0=legal / 0.0=illegal, or nullptr
     int* out_tokens_d,
     const SamplerParams& p,
     cudaStream_t stream
@@ -309,7 +317,7 @@ void gpu_topk_topp_sample(
   dim3 blockA(BLOCK_THREADS, 1, 1);
   stageA_local_topk<K, BLOCK_THREADS, ITEMS_PER_THREAD, T>
       <<<gridA, blockA, 0, stream>>>(
-          logits_d, p.B, p.V, p.temperature, tiles, tile_vals_d, tile_idx_d);
+          logits_d, mask_d, p.B, p.V, p.temperature, tiles, tile_vals_d, tile_idx_d);
 
   // Stage B: one block per batch element
   dim3 gridB(p.B, 1, 1);
@@ -325,23 +333,23 @@ void gpu_topk_topp_sample(
 }
 
 // Explicit instantiations for float
-template void gpu_topk_topp_sample<32, float>(const float*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<64, float>(const float*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<128, float>(const float*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<256, float>(const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<32, float>(const float*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<64, float>(const float*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<128, float>(const float*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<256, float>(const float*, const float*, int*, const SamplerParams&, cudaStream_t);
 
 // Explicit instantiations for __half (f16)
-template void gpu_topk_topp_sample<32, __half>(const __half*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<64, __half>(const __half*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<128, __half>(const __half*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<256, __half>(const __half*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<32, __half>(const __half*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<64, __half>(const __half*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<128, __half>(const __half*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<256, __half>(const __half*, const float*, int*, const SamplerParams&, cudaStream_t);
 
 // Explicit instantiations for __nv_bfloat16 (bf16) - requires sm_80+
 #ifndef NO_BF16_KERNEL
-template void gpu_topk_topp_sample<32, __nv_bfloat16>(const __nv_bfloat16*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<64, __nv_bfloat16>(const __nv_bfloat16*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<128, __nv_bfloat16>(const __nv_bfloat16*, int*, const SamplerParams&, cudaStream_t);
-template void gpu_topk_topp_sample<256, __nv_bfloat16>(const __nv_bfloat16*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<32, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<64, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<128, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
+template void gpu_topk_topp_sample<256, __nv_bfloat16>(const __nv_bfloat16*, const float*, int*, const SamplerParams&, cudaStream_t);
 #endif
 
 
@@ -373,13 +381,52 @@ extern "C" void sampling_f32(
     cudaStream_t stream = (cudaStream_t)stream_ptr;
 
     if (k_eff <= 32) {
-        gpu_topk_topp_sample<32, float>(logits_d, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<32, float>(logits_d, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 64) {
-        gpu_topk_topp_sample<64, float>(logits_d, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<64, float>(logits_d, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 128) {
-        gpu_topk_topp_sample<128, float>(logits_d, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<128, float>(logits_d, nullptr, out_tokens_d, p, stream);
     } else {
-        gpu_topk_topp_sample<256, float>(logits_d, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<256, float>(logits_d, nullptr, out_tokens_d, p, stream);
+    }
+}
+
+extern "C" void sampling_masked_f32(
+    const float* logits_d,
+    const float* mask_d,   // [B,V] 1.0=legal / 0.0=illegal, or nullptr
+    int* out_tokens_d,
+    int B,
+    int V,
+    int K,
+    float temperature,
+    float top_p,
+    uint64_t seed,
+    uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    SamplerParams p;
+    p.B = B;
+    p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample<32, float>(logits_d, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample<64, float>(logits_d, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample<128, float>(logits_d, mask_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample<256, float>(logits_d, mask_d, out_tokens_d, p, stream);
     }
 }
 
@@ -412,13 +459,53 @@ extern "C" void sampling_f16(
     const __half* logits = reinterpret_cast<const __half*>(logits_d);
 
     if (k_eff <= 32) {
-        gpu_topk_topp_sample<32, __half>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<32, __half>(logits, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 64) {
-        gpu_topk_topp_sample<64, __half>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<64, __half>(logits, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 128) {
-        gpu_topk_topp_sample<128, __half>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<128, __half>(logits, nullptr, out_tokens_d, p, stream);
     } else {
-        gpu_topk_topp_sample<256, __half>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<256, __half>(logits, nullptr, out_tokens_d, p, stream);
+    }
+}
+
+extern "C" void sampling_masked_f16(
+    const void* logits_d,
+    const float* mask_d,   // [B,V] 1.0=legal / 0.0=illegal, or nullptr
+    int* out_tokens_d,
+    int B,
+    int V,
+    int K,
+    float temperature,
+    float top_p,
+    uint64_t seed,
+    uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    SamplerParams p;
+    p.B = B;
+    p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+    const __half* logits = reinterpret_cast<const __half*>(logits_d);
+
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample<32, __half>(logits, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample<64, __half>(logits, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample<128, __half>(logits, mask_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample<256, __half>(logits, mask_d, out_tokens_d, p, stream);
     }
 }
 
@@ -452,13 +539,55 @@ extern "C" void sampling_bf16(
     const __nv_bfloat16* logits = reinterpret_cast<const __nv_bfloat16*>(logits_d);
 
     if (k_eff <= 32) {
-        gpu_topk_topp_sample<32, __nv_bfloat16>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<32, __nv_bfloat16>(logits, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 64) {
-        gpu_topk_topp_sample<64, __nv_bfloat16>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<64, __nv_bfloat16>(logits, nullptr, out_tokens_d, p, stream);
     } else if (k_eff <= 128) {
-        gpu_topk_topp_sample<128, __nv_bfloat16>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<128, __nv_bfloat16>(logits, nullptr, out_tokens_d, p, stream);
     } else {
-        gpu_topk_topp_sample<256, __nv_bfloat16>(logits, out_tokens_d, p, stream);
+        gpu_topk_topp_sample<256, __nv_bfloat16>(logits, nullptr, out_tokens_d, p, stream);
+    }
+  #endif
+}
+
+extern "C" void sampling_masked_bf16(
+    const void* logits_d,
+    const float* mask_d,   // [B,V] 1.0=legal / 0.0=illegal, or nullptr
+    int* out_tokens_d,
+    int B,
+    int V,
+    int K,
+    float temperature,
+    float top_p,
+    uint64_t seed,
+    uint64_t token_pos,
+    int64_t stream_ptr)
+{
+    SamplerParams p;
+    p.B = B;
+    p.V = V;
+    p.temperature = temperature;
+    p.top_p = top_p;
+    int k_eff = K <= 0 ? V : K;
+    if (k_eff > V) k_eff = V;
+    if (k_eff < 1) k_eff = 1;
+    if (k_eff > 256) k_eff = 256;
+    p.top_k = k_eff;
+    p.seed = seed;
+    p.token_pos = token_pos;
+
+    cudaStream_t stream = (cudaStream_t)stream_ptr;
+  #ifndef NO_BF16_KERNEL
+    const __nv_bfloat16* logits = reinterpret_cast<const __nv_bfloat16*>(logits_d);
+
+    if (k_eff <= 32) {
+        gpu_topk_topp_sample<32, __nv_bfloat16>(logits, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 64) {
+        gpu_topk_topp_sample<64, __nv_bfloat16>(logits, mask_d, out_tokens_d, p, stream);
+    } else if (k_eff <= 128) {
+        gpu_topk_topp_sample<128, __nv_bfloat16>(logits, mask_d, out_tokens_d, p, stream);
+    } else {
+        gpu_topk_topp_sample<256, __nv_bfloat16>(logits, mask_d, out_tokens_d, p, stream);
     }
   #endif
 }

--- a/src/mamba_cache.rs
+++ b/src/mamba_cache.rs
@@ -1056,14 +1056,14 @@ impl MambaCache {
             Ok(cpu_snapshot) => {
                 self.cpu_prefix_states.insert(hash, cpu_snapshot);
                 self.touch_cpu_prefix_state(hash);
-                tracing::info!(
+                /* tracing::info!(
                     "MambaCache: spilled prefix snapshot {} to CPU (device snapshots {}/{}, cpu snapshots {}/{})",
                     hash,
                     self.prefix_states.len(),
                     self.prefix_cache_capacity,
                     self.cpu_prefix_states.len(),
                     self.cpu_prefix_cache_capacity
-                );
+                ); */
                 true
             }
             Err(err) => {

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -258,6 +258,123 @@ impl Sampler {
         Ok(host_out.into_iter().map(|x| x as u32).collect())
     }
 
+    /// Like `sample_cuda_masked`, but takes a precomputed VOB bitset (`[b, v/32]` u32
+    /// words) instead of a full F32 mask tensor. 8x less data to transfer.
+    /// Each u32 word covers 32 vocab entries: bit i set = token allowed.
+    #[cfg(feature = "cuda")]
+    pub fn sample_cuda_vob(
+        &self,
+        logits: &Tensor,
+        k: usize,
+        p: f32,
+        temperature: f32,
+        seed: u64,
+        vob: Option<&Tensor>, // [b, v/32] U32
+    ) -> Result<Vec<u32>> {
+        let token_pos = self.next_token_pos();
+        use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+        use candle_core::cuda_backend::CudaStorageSlice;
+        use candle_core::cuda_backend::WrapErr;
+        use candle_core::DType;
+
+        let (b, v) = logits.dims2()?;
+        let dev = logits.device().as_cuda_device()?;
+        let dtype = logits.dtype();
+
+        let logits = if !logits.is_contiguous() {
+            logits.contiguous()?
+        } else {
+            logits.clone()
+        };
+        let storage = logits.storage_and_layout().0;
+        let cuda_storage = match &*storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("Sampler expects CUDA tensor"),
+        };
+
+        let vob_ptr: *const u32 = match vob {
+            Some(vob_tensor) => {
+                let (vb, vw) = vob_tensor.dims2()?;
+                if vb != b || vw != v.div_ceil(32) {
+                    candle_core::bail!(
+                        "VOB shape [{}x{}] does not match logits [{}x{}] (expected [{}x{}])",
+                        vb, vw, b, v, b, v.div_ceil(32)
+                    );
+                }
+                let vob_tensor = if vob_tensor.dtype() == DType::U32 {
+                    vob_tensor.contiguous()?
+                } else {
+                    vob_tensor.to_dtype(DType::U32)?.contiguous()?
+                };
+                let (vstorage, _) = vob_tensor.storage_and_layout();
+                match &*vstorage {
+                    candle_core::Storage::Cuda(s) => {
+                        let slice = match &s.slice {
+                            CudaStorageSlice::U32(inp) => inp,
+                            _ => candle_core::bail!("VOB must be U32 storage"),
+                        };
+                        *slice.device_ptr() as *const u32
+                    }
+                    _ => candle_core::bail!("VOB must be a CUDA tensor"),
+                }
+            }
+            None => std::ptr::null(),
+        };
+
+        let out_tokens = unsafe { dev.alloc::<i32>(b) }.w()?;
+        let out_ptr = out_tokens.device_ptr();
+        let stream = *dev.cu_stream() as i64;
+        let out_ptr = *out_ptr as *mut core::ffi::c_void;
+
+        match dtype {
+            DType::F32 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::F32(inp) => *inp.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Dtype mismatch: expected F32 storage"),
+                };
+                unsafe {
+                    ffi::sampling_vob_f32(
+                        logits_ptr, vob_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            DType::F16 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::F16(inp) => *inp.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Dtype mismatch: expected F16 storage"),
+                };
+                unsafe {
+                    ffi::sampling_vob_f16(
+                        logits_ptr, vob_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            DType::BF16 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::BF16(inp) => *inp.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Dtype mismatch: expected BF16 storage"),
+                };
+                unsafe {
+                    ffi::sampling_vob_bf16(
+                        logits_ptr, vob_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            _ => candle_core::bail!(
+                "Sampler only supports F32, F16, and BF16 dtypes, got {:?}",
+                dtype
+            ),
+        }
+
+        let mut host_out = vec![0i32; b];
+        dev.dtoh_sync_copy_into(&out_tokens, &mut host_out).w()?;
+
+        Ok(host_out.into_iter().map(|x| x as u32).collect())
+    }
+
     #[cfg(feature = "metal")]
     pub fn sample(&self, _: &Tensor, _: usize, _: f32, _: f32, _: u64) -> Result<Vec<u32>> {
         candle_core::bail!("Sampler requires CUDA or Metal device")

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -143,6 +143,121 @@ impl Sampler {
         Ok(host_out.into_iter().map(|x| x as u32).collect())
     }
 
+    /// Like `sample_cuda`, but applies a per-row grammar allow-mask in the top-k stage so
+    /// disallowed tokens are never sampled. `mask` is `[b, v]` F32 (1.0 = legal, 0.0 =
+    /// illegal); pass `None` for unmasked sampling (identical to `sample_cuda`).
+    #[cfg(feature = "cuda")]
+    pub fn sample_cuda_masked(
+        &self,
+        logits: &Tensor,
+        k: usize,
+        p: f32,
+        temperature: f32,
+        seed: u64,
+        mask: Option<&Tensor>,
+    ) -> Result<Vec<u32>> {
+        let token_pos = self.next_token_pos();
+        use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+        use candle_core::cuda_backend::CudaStorageSlice;
+        use candle_core::cuda_backend::WrapErr;
+        use candle_core::DType;
+
+        let (b, v) = logits.dims2()?;
+        let dev = logits.device().as_cuda_device()?;
+        let dtype = logits.dtype();
+
+        let logits = if !logits.is_contiguous() {
+            logits.contiguous()?
+        } else {
+            logits.clone()
+        };
+        let storage = logits.storage_and_layout().0;
+        let cuda_storage = match &*storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => candle_core::bail!("Sampler expects CUDA tensor"),
+        };
+
+        // Resolve the mask pointer (null when unmasked).
+        let mask_ptr: *const f32 = match mask {
+            Some(m) => {
+                let (mb, mv) = m.dims2()?;
+                if mb != b || mv != v {
+                    candle_core::bail!("mask shape [{}x{}] does not match logits [{}x{}]", mb, mv, b, v);
+                }
+                let m = if m.dtype() == DType::F32 {
+                    m.contiguous()?
+                } else {
+                    m.to_dtype(DType::F32)?.contiguous()?
+                };
+                let (mstorage, _) = m.storage_and_layout();
+                match &*mstorage {
+                    candle_core::Storage::Cuda(s) => {
+                        let slice = match &s.slice {
+                            CudaStorageSlice::F32(inp) => inp,
+                            _ => candle_core::bail!("mask must be F32 storage"),
+                        };
+                        *slice.device_ptr() as *const f32
+                    }
+                    _ => candle_core::bail!("mask must be a CUDA tensor"),
+                }
+            }
+            None => std::ptr::null(),
+        };
+
+        let out_tokens = unsafe { dev.alloc::<i32>(b) }.w()?;
+        let out_ptr = out_tokens.device_ptr();
+        let stream = *dev.cu_stream() as i64;
+        let out_ptr = *out_ptr as *mut core::ffi::c_void;
+
+        match dtype {
+            DType::F32 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::F32(inp) => *inp.device_ptr() as *const f32,
+                    _ => candle_core::bail!("Dtype mismatch: expected F32 storage"),
+                };
+                unsafe {
+                    ffi::sampling_masked_f32(
+                        logits_ptr, mask_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            DType::F16 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::F16(inp) => *inp.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Dtype mismatch: expected F16 storage"),
+                };
+                unsafe {
+                    ffi::sampling_masked_f16(
+                        logits_ptr, mask_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            DType::BF16 => {
+                let logits_ptr = match &cuda_storage.slice {
+                    CudaStorageSlice::BF16(inp) => *inp.device_ptr() as *const core::ffi::c_void,
+                    _ => candle_core::bail!("Dtype mismatch: expected BF16 storage"),
+                };
+                unsafe {
+                    ffi::sampling_masked_bf16(
+                        logits_ptr, mask_ptr, out_ptr as *mut i32,
+                        b as i32, v as i32, k as i32, temperature, p, seed, token_pos, stream,
+                    );
+                }
+            }
+            _ => candle_core::bail!(
+                "Sampler only supports F32, F16, and BF16 dtypes, got {:?}",
+                dtype
+            ),
+        }
+
+        let mut host_out = vec![0i32; b];
+        dev.dtoh_sync_copy_into(&out_tokens, &mut host_out).w()?;
+
+        Ok(host_out.into_iter().map(|x| x as u32).collect())
+    }
+
     #[cfg(feature = "metal")]
     pub fn sample(&self, _: &Tensor, _: usize, _: f32, _: f32, _: u64) -> Result<Vec<u32>> {
         candle_core::bail!("Sampler requires CUDA or Metal device")

--- a/src/topk.rs
+++ b/src/topk.rs
@@ -304,6 +304,138 @@ pub fn dflash_select_candidates(
     )
 }
 
+/// Grammar-gated DFlash2 candidate-path selection.
+///
+/// Same device walk as `dflash_select_candidates`, plus an optional per-position
+/// allow matrix `allow: [sequence_len, vocab_size]` F32 (1.0 = legal, 0.0 = illegal).
+/// A candidate whose token is disallowed at its position is scored -inf, so the
+/// greedy walk never selects a grammar-illegal token. Pass `None` for the
+/// unmasked path (identical behavior to `dflash_select_candidates`).
+#[cfg(feature = "cuda")]
+pub fn dflash_select_candidates_masked(
+    hidden: &Tensor,
+    unary_logits: &Tensor,
+    candidate_ids: &Tensor,
+    predecessor_codebook: &Tensor,
+    successor_codebook: &Tensor,
+    anchor_token: &Tensor,
+    allow: Option<&Tensor>,
+) -> Result<Tensor> {
+    use candle::cuda_backend::cudarc::driver::DevicePtr;
+    use candle_core::cuda_backend::WrapErr;
+
+    let (sequence_len, rank) = hidden.dims2()?;
+    let (candidate_rows, topk) = unary_logits.dims2()?;
+    if candidate_rows != sequence_len || candidate_ids.dims2()? != (sequence_len, topk) {
+        candle::bail!("DFlash2 candidate selector input shape mismatch");
+    }
+    if predecessor_codebook.dims2()?.1 != rank || successor_codebook.dims2()?.1 != rank {
+        candle::bail!("DFlash2 codebook rank does not match hidden projection");
+    }
+    if anchor_token.dims1()? != 1 {
+        candle::bail!("DFlash2 anchor token must have shape [1]");
+    }
+
+    let dev = hidden.device().as_cuda_device()?;
+    let hidden = if hidden.dtype() == DType::F32 {
+        hidden.contiguous()?
+    } else {
+        hidden.to_dtype(DType::F32)?.contiguous()?
+    };
+    let unary_logits = if unary_logits.dtype() == DType::F32 {
+        unary_logits.contiguous()?
+    } else {
+        unary_logits.to_dtype(DType::F32)?.contiguous()?
+    };
+    let candidate_ids = if candidate_ids.dtype() == DType::U32 {
+        candidate_ids.contiguous()?
+    } else {
+        candidate_ids.to_dtype(DType::U32)?.contiguous()?
+    };
+    let predecessor_codebook = if predecessor_codebook.dtype() == DType::F32 {
+        predecessor_codebook.contiguous()?
+    } else {
+        predecessor_codebook.to_dtype(DType::F32)?.contiguous()?
+    };
+    let successor_codebook = if successor_codebook.dtype() == DType::F32 {
+        successor_codebook.contiguous()?
+    } else {
+        successor_codebook.to_dtype(DType::F32)?.contiguous()?
+    };
+    let anchor_token = if anchor_token.dtype() == DType::U32 {
+        anchor_token.contiguous()?
+    } else {
+        anchor_token.to_dtype(DType::U32)?.contiguous()?
+    };
+
+    let (allow_tensor, vocab_size) = match allow {
+        Some(a) => {
+            if a.dims() != &[sequence_len as i64, a.dim(1)?] {
+                candle::bail!("DFlash2 allow matrix must have shape [sequence_len, vocab_size]");
+            }
+            let vocab_size = a.dim(1)?;
+            let a = if a.dtype() == DType::F32 {
+                a.contiguous()?
+            } else {
+                a.to_dtype(DType::F32)?.contiguous()?
+            };
+            (Some(a), vocab_size)
+        }
+        None => (None, 0),
+    };
+
+    let f32_ptr = |tensor: &Tensor| -> Result<*const f32> {
+        let (storage, _) = tensor.storage_and_layout();
+        match &*storage {
+            candle::Storage::Cuda(storage) => {
+                Ok(*storage.as_cuda_slice::<f32>()?.device_ptr() as *const f32)
+            }
+            _ => candle::bail!("DFlash2 selector tensors must be CUDA tensors"),
+        }
+    };
+    let u32_ptr = |tensor: &Tensor| -> Result<*const u32> {
+        let (storage, _) = tensor.storage_and_layout();
+        match &*storage {
+            candle::Storage::Cuda(storage) => {
+                Ok(*storage.as_cuda_slice::<u32>()?.device_ptr() as *const u32)
+            }
+            _ => candle::bail!("DFlash2 selector tensors must be CUDA tensors"),
+        }
+    };
+
+    let selected_tokens = unsafe { dev.alloc::<u32>(sequence_len) }.w()?;
+    let stream = *dev.cu_stream() as i64;
+    let allow_ptr = match &allow_tensor {
+        Some(a) => f32_ptr(a)?,
+        None => std::ptr::null(),
+    };
+    unsafe {
+        let status = ffi::dflash_select_candidates_masked(
+            f32_ptr(&hidden)? as *const std::ffi::c_void,
+            f32_ptr(&unary_logits)?,
+            u32_ptr(&candidate_ids)?,
+            f32_ptr(&predecessor_codebook)?,
+            f32_ptr(&successor_codebook)?,
+            u32_ptr(&anchor_token)?,
+            allow_ptr,
+            *selected_tokens.device_ptr() as *mut u32,
+            sequence_len as i32,
+            rank as i32,
+            topk as i32,
+            vocab_size as i32,
+            stream,
+        );
+        if status != 0 {
+            candle::bail!("DFlash2 masked candidate selector kernel failed with CUDA error {status}");
+        }
+    }
+    let selected_tokens = candle::CudaStorage::wrap_cuda_slice(selected_tokens, dev.clone());
+    Tensor::from_storage(
+        candle::Storage::Cuda(selected_tokens),
+        candle::Shape::from(sequence_len),
+    )
+}
+
 /// Fused BF16 grouped dynamic depthwise convolution used by DFlash2.
 #[cfg(feature = "cuda")]
 pub fn dflash_grouped_conv_bf16(

--- a/src/topk.rs
+++ b/src/topk.rs
@@ -215,7 +215,6 @@ anchor_token: &Tensor,
     use candle_core::cuda_backend::WrapErr;
 
     let (sequence_len, rank) = hidden.dims2()?;
-    tracing::info!("[dflash-kernel] dflash_select_candidates (unmasked): seq={} rank={}", sequence_len, rank);
     let (candidate_rows, topk) = unary_logits.dims2()?;
     if candidate_rows != sequence_len || candidate_ids.dims2()? != (sequence_len, topk) {
         candle::bail!("DFlash2 candidate selector input shape mismatch");
@@ -327,13 +326,6 @@ pub fn dflash_select_candidates_masked(
 
     let (sequence_len, rank) = hidden.dims2()?;
     let (candidate_rows, topk) = unary_logits.dims2()?;
-    tracing::info!(
-        "[dflash-kernel] dflash_select_candidates_masked: seq={} rank={} topk={} allow={}",
-        sequence_len,
-        rank,
-        topk,
-        allow.is_some()
-    );
     if candidate_rows != sequence_len || candidate_ids.dims2()? != (sequence_len, topk) {
         candle::bail!("DFlash2 candidate selector input shape mismatch");
     }
@@ -593,13 +585,6 @@ pub fn dflash_grouped_conv(
     block_size: usize,
     side: usize,
 ) -> Result<Tensor> {
-    tracing::info!(
-        "[dflash-kernel] dflash_grouped_conv: dtype={:?} seq={} block={} side={}",
-        hidden.dtype(),
-        hidden.dim(0)?,
-        block_size,
-        side
-    );
     match hidden.dtype() {
         DType::BF16 => dflash_grouped_conv_bf16(hidden, delta, base_kernel, block_size, side),
         DType::F16 => dflash_grouped_conv_f16(hidden, delta, base_kernel, block_size, side),

--- a/src/topk.rs
+++ b/src/topk.rs
@@ -209,12 +209,13 @@ pub fn dflash_select_candidates(
     candidate_ids: &Tensor,
     predecessor_codebook: &Tensor,
     successor_codebook: &Tensor,
-    anchor_token: &Tensor,
-) -> Result<Tensor> {
+anchor_token: &Tensor,
+    ) -> Result<Tensor> {
     use candle::cuda_backend::cudarc::driver::DevicePtr;
     use candle_core::cuda_backend::WrapErr;
 
     let (sequence_len, rank) = hidden.dims2()?;
+    tracing::info!("[dflash-kernel] dflash_select_candidates (unmasked): seq={} rank={}", sequence_len, rank);
     let (candidate_rows, topk) = unary_logits.dims2()?;
     if candidate_rows != sequence_len || candidate_ids.dims2()? != (sequence_len, topk) {
         candle::bail!("DFlash2 candidate selector input shape mismatch");
@@ -326,6 +327,13 @@ pub fn dflash_select_candidates_masked(
 
     let (sequence_len, rank) = hidden.dims2()?;
     let (candidate_rows, topk) = unary_logits.dims2()?;
+    tracing::info!(
+        "[dflash-kernel] dflash_select_candidates_masked: seq={} rank={} topk={} allow={}",
+        sequence_len,
+        rank,
+        topk,
+        allow.is_some()
+    );
     if candidate_rows != sequence_len || candidate_ids.dims2()? != (sequence_len, topk) {
         candle::bail!("DFlash2 candidate selector input shape mismatch");
     }
@@ -370,16 +378,16 @@ pub fn dflash_select_candidates_masked(
 
     let (allow_tensor, vocab_size) = match allow {
         Some(a) => {
-            if a.dims() != &[sequence_len as i64, a.dim(1)?] {
+            let a_vocab = a.dim(1)?;
+            if a.dims() != &[sequence_len, a_vocab] {
                 candle::bail!("DFlash2 allow matrix must have shape [sequence_len, vocab_size]");
             }
-            let vocab_size = a.dim(1)?;
             let a = if a.dtype() == DType::F32 {
                 a.contiguous()?
             } else {
                 a.to_dtype(DType::F32)?.contiguous()?
             };
-            (Some(a), vocab_size)
+            (Some(a), a_vocab)
         }
         None => (None, 0),
     };
@@ -585,6 +593,13 @@ pub fn dflash_grouped_conv(
     block_size: usize,
     side: usize,
 ) -> Result<Tensor> {
+    tracing::info!(
+        "[dflash-kernel] dflash_grouped_conv: dtype={:?} seq={} block={} side={}",
+        hidden.dtype(),
+        hidden.dim(0)?,
+        block_size,
+        side
+    );
     match hidden.dtype() {
         DType::BF16 => dflash_grouped_conv_bf16(hidden, delta, base_kernel, block_size, side),
         DType::F16 => dflash_grouped_conv_f16(hidden, delta, base_kernel, block_size, side),


### PR DESCRIPTION
Masking logits from beeing greedy sampled by the drafter reduces errant selection. The mechanism should also allow us to _adjust_ the draft sampler on the fly by generating compensatory masks and passing them into the new entrypoints.